### PR TITLE
kinematic_state: Added warning about temporary vector creation.

### DIFF
--- a/kinematic_state/include/moveit/kinematic_state/joint_state_group.h
+++ b/kinematic_state/include/moveit/kinematic_state/joint_state_group.h
@@ -112,7 +112,8 @@ public:
   /** \brief Perform forward kinematics starting at the roots
       within a group. Links that are not in the group are also
       updated, but transforms for joints that are not in the
-      group are not recomputed.  */
+      group are not recomputed.
+      \warning Creates a temporary std::vector<double> */
   bool setVariableValues(const Eigen::VectorXd& joint_state_values);
 
   /** \brief Perform forward kinematics starting at the roots

--- a/kinematic_state/src/joint_state_group.cpp
+++ b/kinematic_state/src/joint_state_group.cpp
@@ -126,9 +126,9 @@ bool kinematic_state::JointStateGroup::setVariableValues(const std::vector<doubl
 
 bool kinematic_state::JointStateGroup::setVariableValues(const Eigen::VectorXd &joint_state_values)
 {
-  std::vector<double> values;
+  std::vector<double> values(joint_state_values.rows());
   for (std::size_t i = 0; i < joint_state_values.rows(); i++)
-    values.push_back(joint_state_values(i));
+    values[i] =  joint_state_values(i);
   setVariableValues(values);
 }
 


### PR DESCRIPTION
Warn about JointStateGroup::setVariableValues(const Eigen::VectorXd& joint_state_values) creating a temporary std::vector<double> (wasteful if called repeatedly). Also preallocate the vector in the implementation instead of using push_back.
