### PR TITLE
Jacobian using quaternion representation

### DIFF
--- a/robot_state/include/moveit/robot_state/joint_state_group.h
+++ b/robot_state/include/moveit/robot_state/joint_state_group.h
@@ -210,9 +210,11 @@ public:
    * \param link_name The name of the link 
    * \param reference_point_position The reference point position (with respect to the link specified in link_name)
    * \param jacobian The resultant jacobian
+   * \param use_quaternion_representation Flag indicating if the Jacobian should use a quaternion representation (default is false)
    * \return True if jacobian was successfully computed, false otherwise
    */    
-  bool getJacobian(const std::string &link_name, const Eigen::Vector3d &reference_point_position, Eigen::MatrixXd& jacobian) const;
+  bool getJacobian(const std::string &link_name, const Eigen::Vector3d &reference_point_position, Eigen::MatrixXd& jacobian,
+                   bool use_quaterion_representation = false) const;
 
   /** \brief Get the default IK timeout */
   double getDefaultIKTimeout() const


### PR DESCRIPTION
This pull request adds an optional flag to the `getJacobian` API indicating that the user wants a 7xN Jacobian that uses a quaternion representation. I decided a boolean flag is sufficient (instead of an enumerated argument) because there is no compelling reason to support a bunch of other representations (e.g. rotation matrix would result in a 12xN Jacobian... does anyone want that?).

Of course, I realized in implementing this that the conversion is simply a matter of a matrix multiplication. If we really don't like the optional flag, we could instead add a function like
`convertJacobianToQuaternionRepresentation( const MatrixXd &input, MatrixXd &output)` that does the multiplication. However that would heavily penalize speed for people wanting to use this representation because it would require allocating both matrices, whereas my current implementation allocates the Jacobian to the correct size inside of `getJacobian`.

I don't have any tests for this, but I figured it would be good to get feedback/approval before doing more.
