### PR TITLE
Compile error on OS X

### DIFF
--- a/collision_detection/include/moveit/collision_detection/collision_world.h
+++ b/collision_detection/include/moveit/collision_detection/collision_world.h
@@ -37,6 +37,8 @@
 #ifndef MOVEIT_COLLISION_DETECTION_COLLISION_WORLD_
 #define MOVEIT_COLLISION_DETECTION_COLLISION_WORLD_
 
+#include <boost/utility.hpp>
+
 #include <moveit/collision_detection/collision_matrix.h>
 #include <moveit/collision_detection/collision_robot.h>
 #include <moveit/collision_detection/world.h>

--- a/robot_state/src/conversions.cpp
+++ b/robot_state/src/conversions.cpp
@@ -48,7 +48,7 @@ namespace robot_state
 namespace
 {
 
-static bool jointStateToRobotState(const sensor_msgs::JointState &joint_state, RobotState& state, std::set<std::string> *missing)
+static bool _jointStateToRobotState(const sensor_msgs::JointState &joint_state, RobotState& state, std::set<std::string> *missing)
 {
   if (joint_state.name.size() != joint_state.position.size())
   {
@@ -346,7 +346,7 @@ static void msgToAttachedBody(const Transforms *tf, const moveit_msgs::AttachedC
 static bool robotStateMsgToRobotStateHelper(const Transforms *tf, const moveit_msgs::RobotState &robot_state, RobotState& state, bool copy_attached_bodies)
 {
   std::set<std::string> missing;
-  bool result1 = jointStateToRobotState(robot_state.joint_state, state, &missing);
+  bool result1 = _jointStateToRobotState(robot_state.joint_state, state, &missing);
   bool result2 = multiDOFJointsToRobotState(robot_state.multi_dof_joint_state, state, tf);
   state.updateLinkTransforms();
   
@@ -391,7 +391,7 @@ static bool robotStateMsgToRobotStateHelper(const Transforms *tf, const moveit_m
 
 bool robot_state::jointStateToRobotState(const sensor_msgs::JointState &joint_state, RobotState& state)
 {
-  bool result = jointStateToRobotState(joint_state, state, NULL);
+  bool result = _jointStateToRobotState(joint_state, state, NULL);
   state.updateLinkTransforms();
   return result;
 }


### PR DESCRIPTION
Using moveit_core 0.4.3 and building on OS X with Groovy I get:

```
==> Processing catkin package: 'moveit_core'
==> Creating build directory: 'build_isolated/moveit_core'
==> Building with env: '/Users/william/moveit_ws/install_isolated/env.sh'
==> cmake /Users/william/moveit_ws/src/moveit_core -DCATKIN_DEVEL_PREFIX=/Users/william/moveit_ws/devel_isolated/moveit_core -DCMAKE_INSTALL_PREFIX=/Users/william/moveit_ws/install_isolated
-- The C compiler identification is Clang 4.2.0
-- The CXX compiler identification is Clang 4.2.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Found PkgConfig: /usr/local/bin/pkg-config (found version "0.28")
-- checking for module 'eigen3'
--   found eigen3, version 3.1.3
-- Found Eigen: /usr/local/Cellar/eigen/3.1.3/include/eigen3
-- Eigen found (include: /usr/local/Cellar/eigen/3.1.3/include/eigen3)
-- Boost version: 1.53.0
-- Found the following Boost libraries:
--   system
--   filesystem
--   date_time
--   thread
--   iostreams
-- Using CATKIN_DEVEL_PREFIX: /Users/william/moveit_ws/devel_isolated/moveit_core
-- Using CMAKE_PREFIX_PATH: /Users/william/moveit_ws/install_isolated
-- This workspace overlays: /Users/william/moveit_ws/install_isolated
-- Found PythonInterp: /usr/bin/python (found version "2.7.2")
-- Found PY_em: /Library/Python/2.7/site-packages/em.pyc
-- Found gtest: gtests will be built
-- Using CATKIN_TEST_RESULTS_DIR: /Users/william/moveit_ws/build_isolated/moveit_core/test_results
-- catkin 0.5.65
--  *** Building MoveIt! 0.4.3-Alpha ***
--  *** Building MoveIt! Tests ***
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/william/moveit_ws/build_isolated/moveit_core
==> make -j4 -l4 in '/Users/william/moveit_ws/build_isolated/moveit_core'
Scanning dependencies of target moveit_version
Scanning dependencies of target moveit_transforms
Scanning dependencies of target moveit_kinematics_base
Scanning dependencies of target moveit_profiler
[  2%] Building CXX object version/CMakeFiles/moveit_version.dir/version.cpp.o
Linking CXX executable /Users/william/moveit_ws/devel_isolated/moveit_core/lib/moveit_core/moveit_version
[  2%] Built target moveit_version
[  4%] Building CXX object kinematics_base/CMakeFiles/moveit_kinematics_base.dir/src/kinematics_base.cpp.o
Scanning dependencies of target moveit_distance_field
[  6%] Building CXX object transforms/CMakeFiles/moveit_transforms.dir/src/transforms.cpp.o
[  8%] Building CXX object profiler/CMakeFiles/moveit_profiler.dir/src/profiler.cpp.o
[ 10%] Building CXX object distance_field/CMakeFiles/moveit_distance_field.dir/src/distance_field.cpp.o
Linking CXX shared library /Users/william/moveit_ws/devel_isolated/moveit_core/lib/libmoveit_kinematics_base.dylib
[ 10%] Built target moveit_kinematics_base
[ 12%] Building CXX object distance_field/CMakeFiles/moveit_distance_field.dir/src/propagation_distance_field.cpp.o
Linking CXX shared library /Users/william/moveit_ws/devel_isolated/moveit_core/lib/libmoveit_transforms.dylib
[ 12%] Built target moveit_transforms
/Users/william/moveit_ws/src/moveit_core/distance_field/src/propagation_distance_field.cpp:677:1: warning: control reaches end of
      non-void function [-Wreturn-type]
}
^
/Users/william/moveit_ws/src/moveit_core/distance_field/src/propagation_distance_field.cpp:749:1: warning: control may reach end of
      non-void function [-Wreturn-type]
}
^
Linking CXX shared library /Users/william/moveit_ws/devel_isolated/moveit_core/lib/libmoveit_profiler.dylib
[ 12%] Built target moveit_profiler
Scanning dependencies of target moveit_robot_model
[ 14%] [ 16%] [ 18%] Building CXX object robot_model/CMakeFiles/moveit_robot_model.dir/src/link_model.cpp.o
Building CXX object robot_model/CMakeFiles/moveit_robot_model.dir/src/joint_model.cpp.o
Building CXX object robot_model/CMakeFiles/moveit_robot_model.dir/src/fixed_joint_model.cpp.o
2 warnings generated.
Linking CXX shared library /Users/william/moveit_ws/devel_isolated/moveit_core/lib/libmoveit_distance_field.dylib
[ 18%] Built target moveit_distance_field
[ 20%] Building CXX object robot_model/CMakeFiles/moveit_robot_model.dir/src/revolute_joint_model.cpp.o
[ 22%] Building CXX object robot_model/CMakeFiles/moveit_robot_model.dir/src/prismatic_joint_model.cpp.o
[ 24%] Building CXX object robot_model/CMakeFiles/moveit_robot_model.dir/src/planar_joint_model.cpp.o
[ 26%] Building CXX object robot_model/CMakeFiles/moveit_robot_model.dir/src/floating_joint_model.cpp.o
[ 28%] Building CXX object robot_model/CMakeFiles/moveit_robot_model.dir/src/joint_model_group.cpp.o
[ 30%] Building CXX object robot_model/CMakeFiles/moveit_robot_model.dir/src/robot_model.cpp.o
Linking CXX shared library /Users/william/moveit_ws/devel_isolated/moveit_core/lib/libmoveit_robot_model.dylib
[ 30%] Built target moveit_robot_model
Scanning dependencies of target moveit_robot_state
[ 34%] [ 34%] [ 36%] [ 38%] Building CXX object robot_state/CMakeFiles/moveit_robot_state.dir/src/link_state.cpp.o
Building CXX object robot_state/CMakeFiles/moveit_robot_state.dir/src/joint_state.cpp.o
Building CXX object robot_state/CMakeFiles/moveit_robot_state.dir/src/joint_state_group.cpp.o
Building CXX object robot_state/CMakeFiles/moveit_robot_state.dir/src/attached_body.cpp.o
[ 40%] Building CXX object robot_state/CMakeFiles/moveit_robot_state.dir/src/robot_state.cpp.o
[ 42%] Building CXX object robot_state/CMakeFiles/moveit_robot_state.dir/src/conversions.cpp.o
/Users/william/moveit_ws/src/moveit_core/robot_state/src/joint_state_group.cpp:134:1: warning: control reaches end of non-void function
 19   }
      [-Wreturn-type]
}
^
[ 44%] Building CXX object robot_state/CMakeFiles/moveit_robot_state.dir/src/state_transforms.cpp.o
/Users/william/moveit_ws/src/moveit_core/robot_state/src/conversions.cpp:394:17: error: no matching function for call to
      'jointStateToRobotState'
 19   }
   19   }
  bool result = jointStateToRobotState(joint_state, state, NULL);
                ^~~~~~~~~~~~~~~~~~~~~~
/Users/william/moveit_ws/src/moveit_core/robot_state/src/conversions.cpp:392:19: note: candidate function not viable: requires 2
      arguments, but 3 were provided
bool robot_state::jointStateToRobotState(const sensor_msgs::JointState &joint_state, RobotState& state)
                  ^
1 error generated.
make[2]: *** [robot_state/CMakeFiles/moveit_robot_state.dir/src/conversions.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
1 warning generated.
make[1]: *** [robot_state/CMakeFiles/moveit_robot_state.dir/all] Error 2
make: *** [all] Error 2
Traceback (most recent call last):
  File "./src/catkin/bin/../python/catkin/builder.py", line 658, in build_workspace_isolated
    number=index + 1, of=len(ordered_packages)
  File "./src/catkin/bin/../python/catkin/builder.py", line 443, in build_package
    install, jobs, force_cmake, quiet, last_env, cmake_args, make_args
  File "./src/catkin/bin/../python/catkin/builder.py", line 297, in build_catkin_package
    run_command(make_cmd, build_dir, quiet)
  File "./src/catkin/bin/../python/catkin/builder.py", line 186, in run_command
    raise subprocess.CalledProcessError(proc.returncode, ' '.join(cmd))
CalledProcessError: Command '/Users/william/moveit_ws/install_isolated/env.sh make -j4 -l4' returned non-zero exit status 2
<== Failed to process package 'moveit_core':
  Command '/Users/william/moveit_ws/install_isolated/env.sh make -j4 -l4' returned non-zero exit status 2

Reproduce this error by running:
==> /Users/william/moveit_ws/install_isolated/env.sh make -j4 -l4

Command failed, exiting.
```

I tried to fix this problem by adding this diff:

```

```

But then I get this error:

```
==> Processing catkin package: 'moveit_core'
==> Building with env: '/Users/william/moveit_ws/install_isolated/env.sh'
Makefile exists, skipping explicit cmake invocation...
==> make cmake_check_build_system in '/Users/william/moveit_ws/build_isolated/moveit_core'
==> make -j4 -l4 in '/Users/william/moveit_ws/build_isolated/moveit_core'
[  2%] Built target moveit_version
Linking CXX shared library /Users/william/moveit_ws/devel_isolated/moveit_core/lib/libmoveit_kinematics_base.dylib
Linking CXX shared library /Users/william/moveit_ws/devel_isolated/moveit_core/lib/libmoveit_transforms.dylib
Linking CXX shared library /Users/william/moveit_ws/devel_isolated/moveit_core/lib/libmoveit_profiler.dylib
[  4%] Built target moveit_kinematics_base
[  6%] Linking CXX shared library /Users/william/moveit_ws/devel_isolated/moveit_core/lib/libmoveit_distance_field.dylib
Built target moveit_transforms
[  8%] Built target moveit_profiler
[ 12%] Built target moveit_distance_field
Linking CXX shared library /Users/william/moveit_ws/devel_isolated/moveit_core/lib/libmoveit_robot_model.dylib
[ 30%] Built target moveit_robot_model
Scanning dependencies of target moveit_robot_state
[ 32%] Building CXX object robot_state/CMakeFiles/moveit_robot_state.dir/src/conversions.cpp.o
/Users/william/moveit_ws/src/moveit_core/robot_state/src/conversions.cpp:394:73: error: too many arguments to function call, expected
      2, have 3
  bool result = robot_state::jointStateToRobotState(joint_state, state, NULL);
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                     ^~~~
/usr/bin/../lib/clang/4.2/include/stddef.h:47:18: note: expanded from macro 'NULL'
#    define NULL __null
                 ^~~~~~
/Users/william/moveit_ws/src/moveit_core/robot_state/src/conversions.cpp:392:1: note: 'jointStateToRobotState' declared here
bool robot_state::jointStateToRobotState(const sensor_msgs::JointState &joint_state, RobotState& state)
^
1 error generated.
make[2]: *** [robot_state/CMakeFiles/moveit_robot_state.dir/src/conversions.cpp.o] Error 1
make[1]: *** [robot_state/CMakeFiles/moveit_robot_state.dir/all] Error 2
make: *** [all] Error 2
Traceback (most recent call last):
  File "./src/catkin/bin/../python/catkin/builder.py", line 658, in build_workspace_isolated
    number=index + 1, of=len(ordered_packages)
  File "./src/catkin/bin/../python/catkin/builder.py", line 443, in build_package
    install, jobs, force_cmake, quiet, last_env, cmake_args, make_args
  File "./src/catkin/bin/../python/catkin/builder.py", line 297, in build_catkin_package
    run_command(make_cmd, build_dir, quiet)
  File "./src/catkin/bin/../python/catkin/builder.py", line 186, in run_command
    raise subprocess.CalledProcessError(proc.returncode, ' '.join(cmd))
CalledProcessError: Command '/Users/william/moveit_ws/install_isolated/env.sh make -j4 -l4' returned non-zero exit status 2
<== Failed to process package 'moveit_core':
  Command '/Users/william/moveit_ws/install_isolated/env.sh make -j4 -l4' returned non-zero exit status 2

Reproduce this error by running:
==> /Users/william/moveit_ws/install_isolated/env.sh make -j4 -l4

Command failed, exiting.
```

@isucan can you comment on this error? I'm not sure I resolved the correct function here, or if I just need to drop the `NULL`.
