### PR TITLE
enable RTTI for CollisionRequest

### DIFF
--- a/collision_detection/include/moveit/collision_detection/collision_common.h
+++ b/collision_detection/include/moveit/collision_detection/collision_common.h
@@ -181,6 +181,7 @@ namespace collision_detection
                          verbose(false)
     {
     }
+    virtual ~CollisionRequest() {}
 
     /** \brief The group name to check collisions for (optional; if empty, assume the complete robot) */
     std::string group_name;


### PR DESCRIPTION
This allows passing a subclass of CollisionRequest to request more specific results from a specific collision checker.
