### PR TITLE
Added new function to get a robot model by its index

### DIFF
--- a/robot_model/include/moveit/robot_model/robot_model.h
+++ b/robot_model/include/moveit/robot_model/robot_model.h
@@ -130,12 +130,15 @@ public:
   /** \brief Check if a joint exists. Return true if it does. */
   bool hasJointModel(const std::string &name) const;
 
-  /** \brief Get a joint by its name. Throw an exception when the joint is missing. */
+  /** \brief Get a joint by its name. Throw an error when the joint is missing. */
   const JointModel* getJointModel(const std::string &joint) const;
 
-  /** \brief Get a joint by its name. Throw an exception when the joint is missing. */
+  /** \brief Get a joint by its name. Throw an error when the joint is missing. */
   JointModel* getJointModel(const std::string &joint);
-  
+
+  /** \brief Get a joint by its index. Throw an error when the joint is missing. */
+  const JointModel* getJointModel(std::size_t joint_index) const;
+
   /** \brief Get the array of joints, in the order they appear
       in the robot state. */
   const std::vector<const JointModel*>& getJointModels() const
@@ -397,6 +400,9 @@ public:
   
   void getMissingVariableNames(const std::vector<std::string> &variables, std::vector<std::string> &missing_variables) const;
   
+  /** \brief Get the index of a variable in the robot state or return false if the variable does not exist */
+  bool getVariableIndex(const std::string &variable, int &index) const;
+
   /** \brief Get the index of a variable in the robot state */
   int getVariableIndex(const std::string &variable) const;
   

--- a/robot_model/src/robot_model.cpp
+++ b/robot_model/src/robot_model.cpp
@@ -1062,6 +1062,17 @@ moveit::core::JointModel* moveit::core::RobotModel::getJointModel(const std::str
   return NULL;
 }
 
+const moveit::core::JointModel* moveit::core::RobotModel::getJointModel(std::size_t joint_index) const
+{
+  if( joint_index < 0 || joint_index >= joint_model_vector_.size() )
+  {
+    logError("Joint index '%i' out of bounds of joints in model '%s'", joint_index, model_name_.c_str());
+    return NULL;
+  }
+  return joint_model_vector_[joint_index];
+}
+
+
 const moveit::core::LinkModel* moveit::core::RobotModel::getLinkModel(const std::string &name) const
 {
   LinkModelMap::const_iterator it = link_model_map_.find(name);
@@ -1132,11 +1143,35 @@ void moveit::core::RobotModel::getMissingVariableNames(const std::vector<std::st
         missing_variables.push_back(variable_names_[i]);
 }
 
+bool moveit::core::RobotModel::getVariableIndex(const std::string &variable, int &index) const
+{
+  VariableIndexMap::const_iterator it = joint_variables_index_map_.find(variable);
+  if (it == joint_variables_index_map_.end())
+  {
+    return false;
+  }
+
+  index = it->second;
+  return true;
+}
+
 int moveit::core::RobotModel::getVariableIndex(const std::string &variable) const
 {
   VariableIndexMap::const_iterator it = joint_variables_index_map_.find(variable);
   if (it == joint_variables_index_map_.end())
+  {
+    // Error debug information
+    logError("Available variables:");
+
+    for (VariableIndexMap::const_iterator full_it = joint_variables_index_map_.begin();
+         full_it != joint_variables_index_map_.end(); full_it++)
+    {
+        logError("  %i \t %s", full_it->second, full_it->first.c_str());
+    }
+
     throw Exception("Variable '" + variable + "' is not known to model '" + model_name_ + "'");
+  }
+
   return it->second;
 }
 


### PR DESCRIPTION
There is probably another function that has this same functionality, but I couldn't find it/didn't like its name.

I also created a new version of getVariableIndex that returns false if it can't find it, instead of throwing an error.

This is necessary for https://github.com/ros-planning/moveit_ros/pull/308
