### PR TITLE
Fixed doxygen function-grouping.

### DIFF
--- a/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -158,7 +158,7 @@ public:
   robot_state::RobotStatePtr getCurrentStateUpdated(const moveit_msgs::RobotState &update) const;
 
   /**
-   * \defgroup planning_scene_frames Reasoning about frames
+   * \name Reasoning about frames
    */
   /**@{*/
 
@@ -213,7 +213,7 @@ public:
   /**@}*/
   
   /**
-   * \defgroup planning_scene_geometry Reasoning about the geometry of the planning scene
+   * \name Reasoning about the geometry of the planning scene
    */
   /**@{*/
 
@@ -329,7 +329,7 @@ public:
   /**@}*/
 
   /**
-   * \defgroup planning_scene_collision_checking Collision checking with respect to this planning scene
+   * \name Collision checking with respect to this planning scene
    */
   /**@{*/
 
@@ -595,7 +595,7 @@ public:
   /**@}*/
 
   /**
-   * \defgroup planning_scene_distance_computation Distance computation in this planning scene
+   * \name Distance computation
    */
   /**@{*/
   

--- a/robot_model/include/moveit/robot_model/robot_model.h
+++ b/robot_model/include/moveit/robot_model/robot_model.h
@@ -111,7 +111,7 @@ public:
   /** \brief Print information about the constructed model */
   void printModelInfo(std::ostream &out) const;
 
-  /** \defgroup RobotModel_JointModelAccess Access to joint models
+  /** \name Access to joint models
    *  @{
    */
 
@@ -215,7 +215,7 @@ public:
   
   /** @} */
 
-  /** \defgroup RobotModel_LinkModelAccess Access to link models
+  /** \name Access to link models
    *  @{
    */
 
@@ -328,7 +328,7 @@ public:
   double distance(const double *state1, const double *state2) const;  
   void interpolate(const double *from, const double *to, double t, double *state) const;
 
-  /** \defgroup RobotModel_JointGroupModelAccess Access to joint groups
+  /** \name Access to joint groups
    *  @{
    */
   

--- a/robot_state/include/moveit/robot_state/robot_state.h
+++ b/robot_state/include/moveit/robot_state/robot_state.h
@@ -126,7 +126,7 @@ public:
     return robot_model_->getJointModelGroup(group);
   }
   
-  /** \defgroup setVariablePosition_Fn Getting and setting variable position
+  /** \name Getting and setting variable position
    *  @{
    */
   
@@ -205,7 +205,7 @@ public:
   
   /** @} */
 
-  /** \defgroup setVariableVelocity_Fn Getting and setting variable velocity
+  /** \name Getting and setting variable velocity
    *  @{
    */
 
@@ -285,7 +285,7 @@ public:
   /** @} */
 
 
-  /** \defgroup setVariableAcceleration_Fn Getting and setting variable acceleration
+  /** \name Getting and setting variable acceleration
    *  @{
    */
 
@@ -366,7 +366,7 @@ public:
   /** @} */
 
   
-  /** \defgroup setVariableAcceleration_Fn Getting and setting variable effort
+  /** \name Getting and setting variable effort
    *  @{
    */
 
@@ -445,7 +445,7 @@ public:
   
   /** @} */
 
-  /** \defgroup setJointPosition_Fn Getting and setting joint positions, velocities, accelerations and effort
+  /** \name Getting and setting joint positions, velocities, accelerations and effort
    *  @{
    */
   void setJointPositions(const std::string &joint_name, const double *position)
@@ -525,7 +525,7 @@ public:
   /** @} */
   
   
-  /** \defgroup setGroupPosition_Fn Getting and setting group positions
+  /** \name Getting and setting group positions
    *  @{
    */
 
@@ -868,7 +868,7 @@ as the new values that correspond to the group */
   
   /** @} */
 
-  /** \defgroup setGroupPosition_Fn Getting and setting whole states
+  /** \name Getting and setting whole states
    *  @{
    */
   
@@ -889,7 +889,7 @@ as the new values that correspond to the group */
 
   /** @} */
   
-  /** \defgroup RobotStateGetTransforms Updating and getting transforms
+  /** \name Updating and getting transforms
    *  @{
    */
   
@@ -1007,7 +1007,7 @@ as the new values that correspond to the group */
   
   /** @} */
   
-  /** \defgroup distanceFunctions Computing distances
+  /** \name Computing distances
    *  @{
    */
   
@@ -1095,7 +1095,7 @@ as the new values that correspond to the group */
   
   /** @} */
   
-  /** \defgroup RobotStateAttachedBodies Managing attached bodies
+  /** \name Managing attached bodies
    *  @{
    */
   

--- a/transforms/include/moveit/transforms/transforms.h
+++ b/transforms/include/moveit/transforms/transforms.h
@@ -81,7 +81,7 @@ public:
   const std::string& getTargetFrame() const;
 
   /**
-   * \defgroup transforms_settings Setting and retrieving transforms maintained in this class
+   * \name Setting and retrieving transforms maintained in this class
    */
   /**@{*/
 
@@ -124,7 +124,7 @@ public:
   /**@}*/
 
   /**
-   * \defgroup transforms_routines Applying transforms
+   * \name Applying transforms
    */
   /**@{*/
 


### PR DESCRIPTION
\defgroup was used to describe the groups of functions, but that is supposed to
group classes and files into modules.  The grouping of functions was correct in
the code and the \defgroup tags just needed to be changed to \name tags, which then
group the functions nicely within the same page.
