### PR TITLE
Updated tests to new run-time usage of moveit_resources.

### DIFF
--- a/kinematic_constraints/test/test_constraints.cpp
+++ b/kinematic_constraints/test/test_constraints.cpp
@@ -34,13 +34,13 @@
 
 /* Author: Ioan Sucan, E. Gil Jones */
 
-#include <moveit/test_resources/config.h>
 #include <moveit/kinematic_constraints/kinematic_constraint.h>
 #include <gtest/gtest.h>
 #include <urdf_parser/urdf_parser.h>
 #include <fstream>
 #include <eigen_conversions/eigen_msg.h>
 #include <boost/filesystem/path.hpp>
+#include <ros/package.h>
 
 class LoadPlanningModelsPr2 : public testing::Test
 {
@@ -48,9 +48,17 @@ protected:
 
   virtual void SetUp()
   {
+    std::string resource_dir = ros::package::getPath("moveit_resources");
+    if(resource_dir == "")
+    {
+      FAIL() << "Failed to find package moveit_resources.";
+      return;
+    }
+    boost::filesystem::path res_path(resource_dir);
+
     srdf_model.reset(new srdf::Model());
     std::string xml_string;
-    std::fstream xml_file((boost::filesystem::path(MOVEIT_TEST_RESOURCES_DIR) / "urdf/robot.xml").string().c_str(), std::fstream::in);
+    std::fstream xml_file((res_path / "test/urdf/robot.xml").string().c_str(), std::fstream::in);
     if (xml_file.is_open())
     {
       while ( xml_file.good() )
@@ -62,7 +70,7 @@ protected:
       xml_file.close();
       urdf_model = urdf::parseURDF(xml_string);
     }
-    srdf_model->initFile(*urdf_model, (boost::filesystem::path(MOVEIT_TEST_RESOURCES_DIR) / "srdf/robot.xml").string());
+    srdf_model->initFile(*urdf_model, (res_path / "test/srdf/robot.xml").string());
     kmodel.reset(new robot_model::RobotModel(urdf_model, srdf_model));
   };
 

--- a/robot_state/test/test_kinematic_complex.cpp
+++ b/robot_state/test/test_kinematic_complex.cpp
@@ -36,13 +36,13 @@
 
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_state/robot_state.h>
-#include <moveit/test_resources/config.h>
 #include <moveit/robot_state/conversions.h>
 #include <urdf_parser/urdf_parser.h>
 #include <fstream>
 #include <gtest/gtest.h>
 #include <boost/filesystem/path.hpp>
 #include <moveit/profiler/profiler.h>
+#include <ros/package.h>
 
 class LoadPlanningModelsPr2 : public testing::Test
 {
@@ -50,9 +50,17 @@ protected:
   
   virtual void SetUp()
   {
+    std::string resource_dir = ros::package::getPath("moveit_resources");
+    if(resource_dir == "")
+    {
+      FAIL() << "Failed to find package moveit_resources.";
+      return;
+    }
+    boost::filesystem::path res_path(resource_dir);
+
     srdf_model.reset(new srdf::Model());
     std::string xml_string;
-    std::fstream xml_file((boost::filesystem::path(MOVEIT_TEST_RESOURCES_DIR) / "urdf/robot.xml").string().c_str(), std::fstream::in);
+    std::fstream xml_file((res_path / "test/urdf/robot.xml").string().c_str(), std::fstream::in);
     if (xml_file.is_open())
     {
       while (xml_file.good())
@@ -64,7 +72,7 @@ protected:
       xml_file.close();
       urdf_model = urdf::parseURDF(xml_string);
     }
-    srdf_model->initFile(*urdf_model, (boost::filesystem::path(MOVEIT_TEST_RESOURCES_DIR) / "srdf/robot.xml").string());
+    srdf_model->initFile(*urdf_model, (res_path / "test/srdf/robot.xml").string());
     robot_model.reset(new moveit::core::RobotModel(urdf_model, srdf_model));
   };
   


### PR DESCRIPTION
Even though the current travis file for moveit_core succeeds, it does so without ever doing "make tests".  Other packages down the line need to do "make tests", but it was failing for them because some of the tests in moveit_core were not building.  This makes those tests build.  It does not necessarily make them pass... that is future work.

Please do not merge this until the Travis build passes.
