### PR TITLE
More Travis test fixes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ script: # All commands must exit with code 0 on success. Anything else is consid
   - make run_tests_moveit_core_gtest_test_world_diff
   
   # Run downstream tests as well.
-  - make run_tests_moveit_ros_perception
+  # - make run_tests_moveit_ros_perception # this requires glut and therefore a video card.
   - make run_tests_pr2_moveit_tests
 
   # "make run_tests" and friends return success even when tests fail,

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,9 @@ script: # All commands must exit with code 0 on success. Anything else is consid
   # Go to build dir so can use straight "make"
   - cd build
 
+  # Build all tests.
+  - make tests
+
   # Currently not all tests in moveit_core are passing, so I'm
   # automating the running of the ones that *are* passing to prevent
   # regressions in those.  When the other tests are fixed, these
@@ -71,11 +74,16 @@ script: # All commands must exit with code 0 on success. Anything else is consid
   - make run_tests_moveit_core_gtest_test_distance_field
   - make run_tests_moveit_core_gtest_test_robot_model
   - make run_tests_moveit_core_gtest_test_robot_state
+  - make run_tests_moveit_core_gtest_test_robot_state_complex
   - make run_tests_moveit_core_gtest_test_transforms
   - make run_tests_moveit_core_gtest_test_voxel_grid
   - make run_tests_moveit_core_gtest_test_world
   - make run_tests_moveit_core_gtest_test_world_diff
   
+  # Run downstream tests as well.
+  - make run_tests_moveit_ros_perception
+  - make run_tests_pr2_moveit_tests
+
   # "make run_tests" and friends return success even when tests fail,
   # so here we run catkin_test_results which summarizes the results
   # and returns a result code indicating whether there were any

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,15 +124,6 @@ message(STATUS " *** Building MoveIt! ${MOVEIT_VERSION} ***")
 configure_file("version/version.h.in" "${VERSION_FILE_PATH}/moveit/version.h")
 install(FILES "${VERSION_FILE_PATH}/moveit/version.h" DESTINATION include/moveit)
 
-# If the resources package is present, the tests can be built
-set(BUILD_MOVEIT_TESTS FALSE)
-find_package(moveit_resources QUIET)
-if (${moveit_resources_FOUND})
-  message(STATUS " *** Building MoveIt! Tests ***")
-  include_directories(${moveit_resources_INCLUDE_DIRS})
-  set(BUILD_MOVEIT_TESTS TRUE)
-endif()
-
 add_subdirectory(version)
 add_subdirectory(macros)
 add_subdirectory(backtrace)

--- a/constraint_samplers/CMakeLists.txt
+++ b/constraint_samplers/CMakeLists.txt
@@ -22,7 +22,7 @@ install(TARGETS ${MOVEIT_LIB_NAME}
 install(DIRECTORY include/
   DESTINATION include)
 
-if (${BUILD_MOVEIT_TESTS})
+if(CATKIN_ENABLE_TESTING)
   find_package(orocos_kdl)
 
   catkin_add_gtest(test_constraint_samplers

--- a/constraint_samplers/test/test_constraint_samplers.cpp
+++ b/constraint_samplers/test/test_constraint_samplers.cpp
@@ -34,7 +34,6 @@
 
 /* Author: Ioan Sucan */
 
-#include <moveit/test_resources/config.h>
 #include <moveit/planning_scene/planning_scene.h>
 #include <moveit/kinematic_constraints/kinematic_constraint.h>
 #include <moveit/constraint_samplers/default_constraint_samplers.h>
@@ -45,6 +44,7 @@
 #include <moveit/robot_state/conversions.h>
 
 #include <geometric_shapes/shape_operations.h>
+#include <ros/package.h>
 #include <visualization_msgs/MarkerArray.h>
 
 #include <gtest/gtest.h>
@@ -75,9 +75,17 @@ protected:
 
   virtual void SetUp()
   {
+    std::string resource_dir = ros::package::getPath("moveit_resources");
+    if(resource_dir == "")
+    {
+      FAIL() << "Failed to find package moveit_resources.";
+      return;
+    }
+    boost::filesystem::path res_path(resource_dir);
+
     srdf_model.reset(new srdf::Model());
     std::string xml_string;
-    std::fstream xml_file((boost::filesystem::path(MOVEIT_TEST_RESOURCES_DIR) / "urdf/robot.xml").string().c_str(), std::fstream::in);
+    std::fstream xml_file((res_path / "test/urdf/robot.xml").string().c_str(), std::fstream::in);
     if (xml_file.is_open())
     {
       while ( xml_file.good() )
@@ -89,7 +97,7 @@ protected:
       xml_file.close();
       urdf_model = urdf::parseURDF(xml_string);
     }
-    srdf_model->initFile(*urdf_model, (boost::filesystem::path(MOVEIT_TEST_RESOURCES_DIR) / "srdf/robot.xml").string());
+    srdf_model->initFile(*urdf_model, (res_path / "test/srdf/robot.xml").string());
     kmodel.reset(new robot_model::RobotModel(urdf_model, srdf_model));
 
     pr2_kinematics_plugin_right_arm_.reset(new pr2_arm_kinematics::PR2ArmKinematicsPlugin);


### PR DESCRIPTION
Switched test_constraint_samplers.cpp from build-time to run-time reference to moveit_resources.
Added passing run_tests_moveit_core_gtest_test_robot_state_complex test to .travis.yml.
Added 'make tests' to .travis.yml to make all tests, even failing ones.
