### PR TITLE
fix mix-up comments, use getCollisionRobotUnpadded() since this function...

### DIFF
--- a/planning_scene/src/planning_scene.cpp
+++ b/planning_scene/src/planning_scene.cpp
@@ -563,7 +563,7 @@ void planning_scene::PlanningScene::checkCollisionUnpadded(const collision_detec
                                                            const robot_state::RobotState &kstate,
                                                            const collision_detection::AllowedCollisionMatrix& acm) const
 {
-  // check collision with the world using the padded version
+  // check collision with the world using the unpadded version
   getCollisionWorld()->checkRobotCollision(req, res, *getCollisionRobotUnpadded(), kstate, acm);
 
   // do self-collision checking with the unpadded version of the robot


### PR DESCRIPTION
fix comments, in order to avoid confusion, the function checkCollisionUnpadded intentionally uses getCollisionRobotUnpadded()
