### PR TITLE
Fixed asymmetry between planning scene read and write.

### DIFF
--- a/planning_scene/src/planning_scene.cpp
+++ b/planning_scene/src/planning_scene.cpp
@@ -34,6 +34,7 @@
 
 /* Author: Ioan Sucan */
 
+#include <boost/algorithm/string.hpp>
 #include <moveit/planning_scene/planning_scene.h>
 #include <moveit/collision_detection_fcl/collision_detector_allocator_fcl.h>
 #include <geometric_shapes/shape_operations.h>
@@ -1000,6 +1001,7 @@ void planning_scene::PlanningScene::loadGeometryFromStream(std::istream &in)
       std::getline(in, ns);
       if (!in.good() || in.eof())
         return;
+      boost::algorithm::trim(ns);
       unsigned int shape_count;
       in >> shape_count;
       for (std::size_t i = 0 ; i < shape_count && in.good() && !in.eof() ; ++i)


### PR DESCRIPTION
Previously when reading a planning scene, every object would have a " " space prepended onto the name.  If you loaded and saved and loaded and saved the same scene, you would get more and more spaces on the name.  The way it's presented in the GUI does not show up the spaces clearly, so it's not casually evident until you start trying to automate things and finding that the object you want is not there... instead it's called " object".
