### PR TITLE
KinematicsMetrics crashes when called with non-chain groups.

### DIFF
--- a/kinematics_metrics/src/kinematics_metrics.cpp
+++ b/kinematics_metrics/src/kinematics_metrics.cpp
@@ -103,6 +103,12 @@ bool KinematicsMetrics::getManipulabilityIndex(const robot_state::RobotState &st
                                                double &manipulability_index,
                                                bool translation) const
 {
+  // state.getJacobian() only works for chain groups.
+  if(!joint_model_group->isChain())
+  {
+    return false;
+  }
+
   Eigen::MatrixXd jacobian = state.getJacobian(joint_model_group);
   // Get joint limits penalty
   double penalty = getJointLimitsPenalty(state, joint_model_group);
@@ -139,6 +145,12 @@ bool KinematicsMetrics::getManipulabilityEllipsoid(const robot_state::RobotState
                                                    Eigen::MatrixXcd &eigen_values,
                                                    Eigen::MatrixXcd &eigen_vectors) const
 {
+  // state.getJacobian() only works for chain groups.
+  if(!joint_model_group->isChain())
+  {
+    return false;
+  }
+
   Eigen::MatrixXd jacobian = state.getJacobian(joint_model_group);
   Eigen::MatrixXd matrix = jacobian*jacobian.transpose();
   Eigen::EigenSolver<Eigen::MatrixXd> eigensolver(matrix.block(0, 0, 3, 3));
@@ -164,6 +176,11 @@ bool KinematicsMetrics::getManipulability(const robot_state::RobotState &state,
                                           double &manipulability,
                                           bool translation) const
 {
+  // state.getJacobian() only works for chain groups.
+  if(!joint_model_group->isChain())
+  {
+    return false;
+  }
   // Get joint limits penalty
   double penalty = getJointLimitsPenalty(state, joint_model_group);
   if (translation)


### PR DESCRIPTION
This change makes it so the KinematicsMetrics class returns false (failure) instead of causing exceptions to be thrown which no one catches and thus crashes your program.

The ultimate cause is that RobotState::getJacobian() does not have a proper error return value, it throws an exception instead.  That API should ultimately be changed, but this change avoids the crash with no API change and is thus less of a big deal in my opinion.
