### PR TITLE
Added new virtual getName() function to constraint samplers

### DIFF
--- a/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler.h
+++ b/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler.h
@@ -167,8 +167,7 @@ public:
 
   /**
    * \brief Samples given the constraints, populating \e state.
-   * The value DEFAULT_MAX_SAMPLING_ATTEMPTS will be passed in
-   * as the maximum number of attempts to make to take a sample.
+   * This function allows the parameter max_attempts to be set.
    *
    * @param state The state into which the values will be placed. Only values for the group are written. The same state is used as reference if needed.
    * @param [in] max_attempts The maximum number of times to attempt to draw a sample.  If no sample has been drawn in this number of attempts, false will be returned.
@@ -210,10 +209,10 @@ public:
   }
 
   /**
-   * \brief Samples given the constraints, populating the joint state
-   * group.  This function allows the parameter max_attempts to be set.
+   * \brief Samples given the constraints, populating \e state.
+   * This function allows the parameter max_attempts to be set.
    *
-   * @param [out] state The joint state group into which the values will be placed
+   * @param [out] state The state into which the values will be placed. Only values for the group are written.
    * @param [in] reference_state Reference state that will be used to do transforms or perform other actions
    * @param [in] max_attempts The maximum number of times to attempt to draw a sample.  If no sample has been drawn in this number of attempts, false will be returned.
    *
@@ -227,14 +226,14 @@ public:
    * \brief Project a sample given the constraints, updating the joint state
    * group. This function allows the parameter max_attempts to be set.
    *
-   * @param [out] jsg The joint state group which specifies the state to be projected, according to the constraints
-   * @param [in] reference_state Reference state that will be used to do transforms or perform other actions
+   * @param [out] state The state into which the values will be placed. Only values for the group are written.
    * @param [in] max_attempts The maximum number of times to attempt to draw a sample.  If no sample has been drawn in this number of attempts, false will be returned.
    *
    * @return True if a sample was successfully projected, false otherwise
    */
   virtual bool project(robot_state::RobotState &state,
                        unsigned int max_attempts) = 0;
+
   /**
    * \brief Returns whether or not the constraint sampler is valid or not.  To be valid, the joint model group must be available in the kinematic model.
    *
@@ -256,6 +255,13 @@ public:
   {
     verbose_ = flag;
   }
+
+  /**
+   * \brief Get the name of the constraint sampler, for debugging purposes
+   * should be in CamelCase format.
+   * \return string of name
+   */
+  virtual std::string getName() = 0;
 
 protected:
 

--- a/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler.h
+++ b/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler.h
@@ -261,7 +261,7 @@ public:
    * should be in CamelCase format.
    * \return string of name
    */
-  virtual std::string getName() = 0;
+  virtual const std::string& getName() const = 0;
 
 protected:
 

--- a/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
+++ b/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
@@ -152,9 +152,10 @@ public:
    * should be in CamelCase format.
    * \return string of name
    */
-  virtual std::string getName()
+  virtual const std::string& getName() const
   {
-    return "JointConstraintSampler";
+    static const std::string SAMPLER_NAME = "JointConstraintSampler";
+    return SAMPLER_NAME;
   }
 
 protected:
@@ -482,9 +483,10 @@ public:
    * should be in CamelCase format.
    * \return string of name
    */
-  virtual std::string getName()
+  virtual const std::string& getName() const
   {
-    return "IKConstraintSampler";
+    static const std::string SAMPLER_NAME = "IKConstraintSampler";
+    return SAMPLER_NAME;
   }
 
 protected:

--- a/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
+++ b/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
@@ -147,6 +147,16 @@ public:
     return unbounded_.size();
   }
 
+  /**
+   * \brief Get the name of the constraint sampler, for debugging purposes
+   * should be in CamelCase format.
+   * \return string of name
+   */
+  virtual std::string getName()
+  {
+    return "JointConstraintSampler";
+  }
+
 protected:
 
   /// \brief An internal structure used for maintaining constraints on a particular joint
@@ -466,6 +476,16 @@ public:
    * @return True if a sample was successfully produced, otherwise false
    */
   bool samplePose(Eigen::Vector3d &pos, Eigen::Quaterniond &quat, const robot_state::RobotState &ks, unsigned int max_attempts);
+
+  /**
+   * \brief Get the name of the constraint sampler, for debugging purposes
+   * should be in CamelCase format.
+   * \return string of name
+   */
+  virtual std::string getName()
+  {
+    return "IKConstraintSampler";
+  }
 
 protected:
 

--- a/constraint_samplers/include/moveit/constraint_samplers/union_constraint_sampler.h
+++ b/constraint_samplers/include/moveit/constraint_samplers/union_constraint_sampler.h
@@ -154,6 +154,16 @@ public:
 
   virtual bool project(robot_state::RobotState &state, unsigned int max_attempts);
 
+  /**
+   * \brief Get the name of the constraint sampler, for debugging purposes
+   * should be in CamelCase format.
+   * \return string of name
+   */
+  virtual std::string getName()
+  {
+    return "UnionConstraintSampler";
+  }
+
 protected:
 
   std::vector<ConstraintSamplerPtr> samplers_; /**< \brief Holder for sorted internal list of samplers*/

--- a/constraint_samplers/include/moveit/constraint_samplers/union_constraint_sampler.h
+++ b/constraint_samplers/include/moveit/constraint_samplers/union_constraint_sampler.h
@@ -159,9 +159,10 @@ public:
    * should be in CamelCase format.
    * \return string of name
    */
-  virtual std::string getName()
+  virtual const std::string& getName() const
   {
-    return "UnionConstraintSampler";
+    static const std::string SAMPLER_NAME = "UnionConstraintSampler";
+    return SAMPLER_NAME;
   }
 
 protected:

--- a/constraint_samplers/src/union_constraint_sampler.cpp
+++ b/constraint_samplers/src/union_constraint_sampler.cpp
@@ -147,3 +147,4 @@ bool constraint_samplers::UnionConstraintSampler::project(robot_state::RobotStat
       return false;
   return true;
 }
+


### PR DESCRIPTION
This is for easier debugging and plugin management. I don't know of anyone who has created their own constraint samplers yet, but I'm in the process of implementing one. Its hard to debug MoveIt! when plugins have no way to identify themselves into terminal, so I've added this function.

Because it modified the constraint_sampler plugin header by adding a new virtual function, it might be better to merge this into a new indigo-branch for ABI compatibility. I'm not an expert on this.

Also, there are some documentation fixes. 
