### PR TITLE
KinematicsBase support for multiple tip frames and IK requests with multiple poses

### DIFF
--- a/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -32,7 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Author: Sachin Chitta */
+/* Author: Sachin Chitta, Dave Coleman */
 
 #ifndef MOVEIT_KINEMATICS_BASE_KINEMATICS_BASE_
 #define MOVEIT_KINEMATICS_BASE_KINEMATICS_BASE_

--- a/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -404,13 +404,23 @@ public:
 
 
   /**
-   * \brief Only kinematic solvers know if they support a particular kinematic configuration, put the burden on them
-   *        to return an explanation of why they are unable to service a joint model group
-   *        Default implementation for legacy solvers provided
-   * \param JointModelGroup - the planning group being proposed to be solved by this IK solver
-   * \return a string specifying the reason the joint model group is not supported, or an empty string if supported
+   * \brief Check if this solver supports a given JointModelGroup.
+   *
+   * Override this function to check if your kinematics solver
+   * implementation supports the given group.
+   *
+   * The default implementation just returns jmg->isChain(), since
+   * solvers written before this function was added all supported only
+   * chain groups.
+   *
+   * \param jmg the planning group being proposed to be solved by this IK solver
+   * \param error_text_out If this pointer is non-null and the group is
+   *          not supported, this is filled with a description of why it's not
+   *          supported.
+   * \return True if the group is supported, false if not.
    */
-  virtual const std::string supportsGroup(const moveit::core::JointModelGroup *jmg) const;
+  virtual const bool supportsGroup(const moveit::core::JointModelGroup *jmg,
+                                   std::string* error_text_out = NULL) const;
 
   /**
    * @brief  Set the search discretization

--- a/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -43,6 +43,14 @@
 #include <console_bridge/console.h>
 #include <string>
 
+namespace moveit
+{
+namespace core
+{
+class JointModelGroup;
+}
+}
+
 /** @brief API for forward and inverse kinematics */
 namespace kinematics
 {
@@ -393,6 +401,16 @@ public:
    * @brief  Return all the link names in the order they are represented internally
    */
   virtual const std::vector<std::string>& getLinkNames() const = 0;
+
+
+  /**
+   * \brief Only kinematic solvers know if they support a particular kinematic configuration, put the burden on them
+   *        to return an explanation of why they are unable to service a joint model group
+   *        Default implementation for legacy solvers provided
+   * \param JointModelGroup - the planning group being proposed to be solved by this IK solver
+   * \return a string specifying the reason the joint model group is not supported, or an empty string if supported
+   */
+  virtual const std::string supportsGroup(const moveit::core::JointModelGroup *jmg) const;
 
   /**
    * @brief  Set the search discretization

--- a/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -180,8 +180,8 @@ public:
                                 const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const = 0;
 
   /**
-   * @brief Given a set of desired poses for a planning group with multiple end-effectors, search for the joint angles 
-   * required to reach it them. This is useful for e.g. biped robots that need to perform whole-body IK. 
+   * @brief Given a set of desired poses for a planning group with multiple end-effectors, search for the joint angles
+   * required to reach them. This is useful for e.g. biped robots that need to perform whole-body IK.
    * Not necessary for most robots that have kinematic chains.
    * This particular method is intended for "searching" for a solutions by stepping through the redundancy
    * (or other numerical routines).
@@ -208,7 +208,7 @@ public:
     // For IK solvers that do not support multiple poses, fall back to single pose call
     if (ik_poses.size() == 1)
     {
-      return searchPositionIK(ik_poses[0], 
+      return searchPositionIK(ik_poses[0],
         ik_seed_state,
         timeout,
         consistency_limits,
@@ -236,7 +236,8 @@ public:
 
   /**
    * @brief Set the parameters for the solver, for use with kinematic chain IK solvers
-   * @param robot_description This parameter can be used as an identifier for the robot kinematics is computed for; For example, rhe name of the ROS parameter that contains the robot description;
+   * @param robot_description This parameter can be used as an identifier for the robot kinematics it is computed for;
+   * For example, the name of the ROS parameter that contains the robot description;
    * @param group_name The group for which this solver is being configured
    * @param base_frame The base frame in which all input poses are expected.
    * This may (or may not) be the root frame of the chain that the solver operates on
@@ -251,7 +252,8 @@ public:
 
   /**
    * @brief Set the parameters for the solver, for use with non-chain IK solvers
-   * @param robot_description This parameter can be used as an identifier for the robot kinematics is computed for; For example, rhe name of the ROS parameter that contains the robot description;
+   * @param robot_description This parameter can be used as an identifier for the robot kinematics it is computed for;
+   * For example, the name of the ROS parameter that contains the robot description;
    * @param group_name The group for which this solver is being configured
    * @param base_frame The base frame in which all input poses are expected.
    * This may (or may not) be the root frame of the chain that the solver operates on
@@ -266,7 +268,8 @@ public:
 
   /**
    * @brief  Initialization function for the kinematics, for use with kinematic chain IK solvers
-   * @param robot_description This parameter can be used as an identifier for the robot kinematics is computed for; For example, rhe name of the ROS parameter that contains the robot description;
+   * @param robot_description This parameter can be used as an identifier for the robot kinematics it is computed for;
+   * For example, the name of the ROS parameter that contains the robot description;
    * @param group_name The group for which this solver is being configured
    * @param base_frame The base frame in which all input poses are expected.
    * This may (or may not) be the root frame of the chain that the solver operates on
@@ -282,7 +285,8 @@ public:
 
   /**
    * @brief  Initialization function for the kinematics, for use with non-chain IK solvers
-   * @param robot_description This parameter can be used as an identifier for the robot kinematics is computed for; For example, rhe name of the ROS parameter that contains the robot description;
+   * @param robot_description This parameter can be used as an identifier for the robot kinematics is computed for;
+   * For example, rhe name of the ROS parameter that contains the robot description;
    * @param group_name The group for which this solver is being configured
    * @param base_frame The base frame in which all input poses are expected.
    * This may (or may not) be the root frame of the chain that the solver operates on
@@ -320,7 +324,8 @@ public:
   }
 
   /**
-   * @brief  Return the name of the frame in which the solver is operating. This is usually a link name. No namespacing (e.g., no "/" prefix) should be used.
+   * @brief  Return the name of the frame in which the solver is operating. This is usually a link name.
+   * No namespacing (e.g., no "/" prefix) should be used.
    * @return The string name of the frame in which the solver is operating
    */
   virtual const std::string& getBaseFrame() const
@@ -329,7 +334,8 @@ public:
   }
 
   /**
-   * @brief  Return the name of the tip frame of the chain on which the solver is operating. This is usually a link name. No namespacing (e.g., no "/" prefix) should be used.
+   * @brief  Return the name of the tip frame of the chain on which the solver is operating. This is usually a link name.
+   * No namespacing (e.g., no "/" prefix) should be used.
    * Deprecated in favor of getTipFrames(), but will remain for foreseeable future for backwards compatibility
    * @return The string name of the tip frame of the chain on which the solver is operating
    */
@@ -342,7 +348,7 @@ public:
   }
 
   /**
-   * @brief  Return the names of the tip frames of the kinematic tree on which the solver is operating. 
+   * @brief  Return the names of the tip frames of the kinematic tree on which the solver is operating.
    * This is usually a link name. No namespacing (e.g., no "/" prefix) should be used.
    * @return The vector of names of the tip frames of the kinematic tree on which the solver is operating
    */
@@ -352,7 +358,8 @@ public:
   }
 
   /**
-   * @brief Set a set of redundant joints for the kinematics solver to use.  This can fail, depending on the IK solver and choice of redundant joints!
+   * @brief Set a set of redundant joints for the kinematics solver to use.
+   * This can fail, depending on the IK solver and choice of redundant joints!
    * @param redundant_joint_indices The set of redundant joint indices (corresponding to
    * the list of joints you get from getJointNames()).
    * @return False if any of the input joint indices are invalid (exceed number of
@@ -410,7 +417,8 @@ public:
     default_timeout_ = timeout;
   }
 
-  /** @brief For functions that require a timeout specified but one is not specified using arguments, this default timeout is used */
+  /** @brief For functions that require a timeout specified but one is not specified using arguments,
+      this default timeout is used */
   double getDefaultTimeout() const
   {
     return default_timeout_;
@@ -424,7 +432,8 @@ public:
   KinematicsBase() :
     search_discretization_(DEFAULT_SEARCH_DISCRETIZATION),
     default_timeout_(DEFAULT_TIMEOUT),
-    tip_frame_("DEPRECATED") // help users understand why this variable might not be set (if multiple tip frames provided, this variable will be unset)
+    tip_frame_("DEPRECATED") // help users understand why this variable might not be set
+                             // (if multiple tip frames provided, this variable will be unset)
   {}
 
 protected:
@@ -433,7 +442,8 @@ protected:
   std::string group_name_;
   std::string base_frame_;
   std::vector<std::string> tip_frames_;
-  std::string tip_frame_; // DEPRECATED - this variable only still exists for backwards compatibility with previously generated custom ik solvers like IKFast
+  std::string tip_frame_; // DEPRECATED - this variable only still exists for backwards compatibility with
+                          // previously generated custom ik solvers like IKFast
   double search_discretization_;
   double default_timeout_;
   std::vector<unsigned int> redundant_joint_indices_;

--- a/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -149,7 +149,6 @@ public:
    * @param ik_seed_state an initial guess solution for the inverse kinematics
    * @param timeout The amount of time (in seconds) available to the solver
    * @param solution the solution vector
-   * @param desired_pose_callback A callback function for the desired link pose - could be used, e.g. to check for collisions for the end-effector
    * @param solution_callback A callback solution for the IK solution
    * @param error_code an error code that encodes the reason for failure or success
    * @param lock_redundant_joints if setRedundantJoints() was previously called, keep the values of the joints marked as redundant the same as in the seed
@@ -172,7 +171,6 @@ public:
    * @param timeout The amount of time (in seconds) available to the solver
    * @param consistency_limits the distance that any joint in the solution can be from the corresponding joints in the current seed state
    * @param solution the solution vector
-   * @param desired_pose_callback A callback function for the desired link pose - could be used, e.g. to check for collisions for the end-effector
    * @param solution_callback A callback solution for the IK solution
    * @param error_code an error code that encodes the reason for failure or success
    * @param lock_redundant_joints if setRedundantJoints() was previously called, keep the values of the joints marked as redundant the same as in the seed
@@ -198,7 +196,6 @@ public:
    * @param timeout The amount of time (in seconds) available to the solver
    * @param consistency_limits the distance that any joint in the solution can be from the corresponding joints in the current seed state
    * @param solution the solution vector
-   * @param desired_pose_callback A callback function for the desired link pose - could be used, e.g. to check for collisions for the end-effector
    * @param solution_callback A callback solution for the IK solution
    * @param error_code an error code that encodes the reason for failure or success
    * @param lock_redundant_joints if setRedundantJoints() was previously called, keep the values of the joints marked as redundant the same as in the seed
@@ -216,14 +213,28 @@ public:
     // For IK solvers that do not support multiple poses, fall back to single pose call
     if (ik_poses.size() == 1)
     {
-      return searchPositionIK(ik_poses[0],
-        ik_seed_state,
-        timeout,
-        consistency_limits,
-        solution,
-        solution_callback,
-        error_code,
-        options);
+      // Check if a solution_callback function was provided and call the corresponding function
+      if (solution_callback)
+      {
+        return searchPositionIK(ik_poses[0],
+          ik_seed_state,
+          timeout,
+          consistency_limits,
+          solution,
+          solution_callback,
+          error_code,
+          options);
+      }
+      else
+      {
+        return searchPositionIK(ik_poses[0],
+          ik_seed_state,
+          timeout,
+          consistency_limits,
+          solution,
+          error_code,
+          options);
+      }
     }
 
     // Otherwise throw error because this function should have been implemented

--- a/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -55,14 +55,12 @@ struct KinematicsQueryOptions
 {
   KinematicsQueryOptions() :
     lock_redundant_joints(false),
-    return_approximate_solution(false),
-    solve_non_chains(false)
+    return_approximate_solution(false)
   {
   }
 
   bool lock_redundant_joints;
   bool return_approximate_solution;
-  bool solve_non_chains;
 };
 
 
@@ -133,7 +131,7 @@ public:
                                 const std::vector<double> &consistency_limits,
                                 std::vector<double> &solution,
                                 moveit_msgs::MoveItErrorCodes &error_code,
-    const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const = 0;
+                                const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const = 0;
 
   /**
    * @brief Given a desired pose of the end-effector, search for the joint angles required to reach it.
@@ -219,11 +217,9 @@ public:
         error_code,
         options);
     }
-    else
-    {
-      // Otherwise throw error
-      logError("moveit.kinematics_base: This kinematic solver does not support searchPositionIK with multiple poses");
-    }
+
+    // Otherwise throw error because this function should have been implemented
+    logError("moveit.kinematics_base: This kinematic solver does not support searchPositionIK with multiple poses");
     return false;
   }
 
@@ -239,7 +235,7 @@ public:
                              std::vector<geometry_msgs::Pose> &poses) const = 0;
 
   /**
-   * @brief Set the parameters for the solver
+   * @brief Set the parameters for the solver, for use with kinematic chain IK solvers
    * @param robot_description This parameter can be used as an identifier for the robot kinematics is computed for; For example, rhe name of the ROS parameter that contains the robot description;
    * @param group_name The group for which this solver is being configured
    * @param base_frame The base frame in which all input poses are expected.
@@ -254,12 +250,12 @@ public:
                          double search_discretization);
 
   /**
-   * @brief Set the parameters for the solver
+   * @brief Set the parameters for the solver, for use with non-chain IK solvers
    * @param robot_description This parameter can be used as an identifier for the robot kinematics is computed for; For example, rhe name of the ROS parameter that contains the robot description;
    * @param group_name The group for which this solver is being configured
    * @param base_frame The base frame in which all input poses are expected.
    * This may (or may not) be the root frame of the chain that the solver operates on
-   * @param tip_frame The tip of the chain
+   * @param tip_frames A vector of tips of the kinematic tree
    * @param search_discretization The discretization of the search when the solver steps through the redundancy
    */
   virtual void setValues(const std::string& robot_description,
@@ -269,7 +265,7 @@ public:
                          double search_discretization);
 
   /**
-   * @brief  Initialization function for the kinematics
+   * @brief  Initialization function for the kinematics, for use with kinematic chain IK solvers
    * @param robot_description This parameter can be used as an identifier for the robot kinematics is computed for; For example, rhe name of the ROS parameter that contains the robot description;
    * @param group_name The group for which this solver is being configured
    * @param base_frame The base frame in which all input poses are expected.
@@ -285,12 +281,12 @@ public:
                           double search_discretization) = 0;
 
   /**
-   * @brief  Initialization function for the kinematics
+   * @brief  Initialization function for the kinematics, for use with non-chain IK solvers
    * @param robot_description This parameter can be used as an identifier for the robot kinematics is computed for; For example, rhe name of the ROS parameter that contains the robot description;
    * @param group_name The group for which this solver is being configured
    * @param base_frame The base frame in which all input poses are expected.
    * This may (or may not) be the root frame of the chain that the solver operates on
-   * @param tip_frame The tip of the chain
+   * @param tip_frames A vector of tips of the kinematic tree
    * @param search_discretization The discretization of the search when the solver steps through the redundancy
    * @return True if initialization was successful, false otherwise
    */
@@ -346,8 +342,9 @@ public:
   }
 
   /**
-   * @brief  Return the name of the tip frame of the chain on which the solver is operating. This is usually a link name. No namespacing (e.g., no "/" prefix) should be used.
-   * @return The string name of the tip frame of the chain on which the solver is operating
+   * @brief  Return the names of the tip frames of the kinematic tree on which the solver is operating. 
+   * This is usually a link name. No namespacing (e.g., no "/" prefix) should be used.
+   * @return The vector of names of the tip frames of the kinematic tree on which the solver is operating
    */
   virtual const std::vector<std::string>& getTipFrames() const
   {
@@ -427,7 +424,7 @@ public:
   KinematicsBase() :
     search_discretization_(DEFAULT_SEARCH_DISCRETIZATION),
     default_timeout_(DEFAULT_TIMEOUT),
-    tip_frame_("DEPRECATED") // help users understand why this variable might not be set (if provide multiple tip frames, this variable will be unset)
+    tip_frame_("DEPRECATED") // help users understand why this variable might not be set (if multiple tip frames provided, this variable will be unset)
   {}
 
 protected:

--- a/kinematics_base/src/kinematics_base.cpp
+++ b/kinematics_base/src/kinematics_base.cpp
@@ -32,7 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Author: Sachin Chitta */
+/* Author: Sachin Chitta, Dave Coleman */
 
 #include <moveit/kinematics_base/kinematics_base.h>
 

--- a/kinematics_base/src/kinematics_base.cpp
+++ b/kinematics_base/src/kinematics_base.cpp
@@ -48,8 +48,27 @@ void kinematics::KinematicsBase::setValues(const std::string& robot_description,
   robot_description_ = robot_description;
   group_name_ = group_name;
   base_frame_ = removeSlash(base_frame);
-  tip_frame_ = removeSlash(tip_frame);
+  tip_frames_.push_back(removeSlash(tip_frame));
+  tip_frame_ = tip_frame; // for backwards compatibility
   search_discretization_ = search_discretization;
+}
+
+void kinematics::KinematicsBase::setValues(const std::string& robot_description,
+                       const std::string& group_name,
+                       const std::string& base_frame,
+                       const std::vector<std::string>& tip_frames,
+                       double search_discretization)
+{
+  robot_description_ = robot_description;
+  group_name_ = group_name;
+  base_frame_ = removeSlash(base_frame);
+  search_discretization_ = search_discretization;
+
+  // Copy tip frames to local vector after stripping slashes
+  for (std::size_t i = 0; i < tip_frames.size(); ++i)
+    tip_frames_.push_back(removeSlash(tip_frames[i]));
+
+  // Note that we do not set tip_frame_ variable here, because it should never be used in combination with multiple tip frames
 }
 
 bool kinematics::KinematicsBase::setRedundantJoints(const std::vector<unsigned int> &redundant_joint_indices)

--- a/kinematics_base/src/kinematics_base.cpp
+++ b/kinematics_base/src/kinematics_base.cpp
@@ -107,13 +107,18 @@ std::string kinematics::KinematicsBase::removeSlash(const std::string &str) cons
   return (!str.empty() && str[0] == '/') ? removeSlash(str.substr(1)) : str;
 }
 
-const std::string kinematics::KinematicsBase::supportsGroup(const moveit::core::JointModelGroup *jmg) const
+const bool kinematics::KinematicsBase::supportsGroup(const moveit::core::JointModelGroup *jmg,
+                                                     std::string* error_text_out) const
 {
   // Default implementation for legacy solvers:
   if (!jmg->isChain())
   {
-    return "This plugin only supports joint groups which are chains";
+    if(error_text_out)
+    {
+      *error_text_out = "This plugin only supports joint groups which are chains";
+    }
+    return false;
   }
 
-  return "";
+  return true;
 }

--- a/kinematics_base/src/kinematics_base.cpp
+++ b/kinematics_base/src/kinematics_base.cpp
@@ -35,6 +35,7 @@
 /* Author: Sachin Chitta, Dave Coleman */
 
 #include <moveit/kinematics_base/kinematics_base.h>
+#include <moveit/robot_model/joint_model_group.h>
 
 const double kinematics::KinematicsBase::DEFAULT_SEARCH_DISCRETIZATION = 0.1;
 const double kinematics::KinematicsBase::DEFAULT_TIMEOUT = 1.0;
@@ -104,4 +105,15 @@ bool kinematics::KinematicsBase::setRedundantJoints(const std::vector<std::strin
 std::string kinematics::KinematicsBase::removeSlash(const std::string &str) const
 {
   return (!str.empty() && str[0] == '/') ? removeSlash(str.substr(1)) : str;
+}
+
+const std::string kinematics::KinematicsBase::supportsGroup(const moveit::core::JointModelGroup *jmg) const
+{
+  // Default implementation for legacy solvers:
+  if (!jmg->isChain())
+  {
+    return "This plugin only supports joint groups which are chains";
+  }
+
+  return "";
 }

--- a/kinematics_base/src/kinematics_base.cpp
+++ b/kinematics_base/src/kinematics_base.cpp
@@ -65,10 +65,13 @@ void kinematics::KinematicsBase::setValues(const std::string& robot_description,
   search_discretization_ = search_discretization;
 
   // Copy tip frames to local vector after stripping slashes
+  tip_frames_.clear();
   for (std::size_t i = 0; i < tip_frames.size(); ++i)
     tip_frames_.push_back(removeSlash(tip_frames[i]));
 
-  // Note that we do not set tip_frame_ variable here, because it should never be used in combination with multiple tip frames
+  // Copy tip frames to our legacy variable if only one tip frame is passed in the input vector. Remove eventually.
+  if (tip_frames.size() == 1)
+    tip_frame_ = tip_frames[0];
 }
 
 bool kinematics::KinematicsBase::setRedundantJoints(const std::vector<unsigned int> &redundant_joint_indices)

--- a/kinematics_base/src/kinematics_base.cpp
+++ b/kinematics_base/src/kinematics_base.cpp
@@ -48,8 +48,8 @@ void kinematics::KinematicsBase::setValues(const std::string& robot_description,
   robot_description_ = robot_description;
   group_name_ = group_name;
   base_frame_ = removeSlash(base_frame);
+  tip_frame_ = removeSlash(tip_frame); // for backwards compatibility
   tip_frames_.push_back(removeSlash(tip_frame));
-  tip_frame_ = tip_frame; // for backwards compatibility
   search_discretization_ = search_discretization;
 }
 

--- a/kinematics_base/src/kinematics_base.cpp
+++ b/kinematics_base/src/kinematics_base.cpp
@@ -71,7 +71,7 @@ void kinematics::KinematicsBase::setValues(const std::string& robot_description,
 
   // Copy tip frames to our legacy variable if only one tip frame is passed in the input vector. Remove eventually.
   if (tip_frames.size() == 1)
-    tip_frame_ = tip_frames[0];
+    tip_frame_ = removeSlash(tip_frames[0]);
 }
 
 bool kinematics::KinematicsBase::setRedundantJoints(const std::vector<unsigned int> &redundant_joint_indices)

--- a/robot_state/src/conversions.cpp
+++ b/robot_state/src/conversions.cpp
@@ -360,16 +360,6 @@ static bool _robotStateMsgToRobotStateHelper(const Transforms *tf, const moveit_
             missing.erase(vnames[i]);
         }
       }
-
-    // Create error message
-    if (!missing.empty())
-    {
-      std::stringstream missing_frames;
-      std::copy(missing.begin(), missing.end(), std::ostream_iterator<std::string>(missing_frames, ", "));
-      logError("robot_state: State message is missing required frames: [%s]", missing_frames.str().c_str());
-      return false;
-    }
-
     return true;
   }
   else


### PR DESCRIPTION
This PR only modifies KinematicsBase functionality to make review easier, though changes will be needed elsewhere in robot_state and moveit_ros to enable full non-chain IK support.

This introduces 3 new functions that optionally allow multiple tips and poses to be passed into KinematicsBase:

`searchPositionIK()` - allows a vector of poses to be passed in
`setValues()` - allows a vector of frame tips to be passed in
`initialize()` - allows a vector of frame tips to be passed in
`getTipFrames()` - returns a vector of tips instead of just one

The old `std::string tip_frame_` member variable is a bit messy in that we cannot remove it without breaking older code like generated IKFast solver code. Thus, this variable must remain in for the time being. The results in a little bit of duplicate information if you are using the IK solver in the normal case of a chain solver in that your tip frame name is saved in both the string and in the vector. I've done my best to document the deprecated status of this variable throughout the code and in the future I think it should be removed. 

I have tested these modifications against KDL, IKFast, and our custom full body IK solver.

The following PRs depends on these changes:
[Allow planning groups to have more than one tip](https://github.com/ros-planning/moveit_ros/pull/431)
[Allow joint model group to have use IK solvers with multiple tip frames](https://github.com/ros-planning/moveit_core/pull/155)
