### PR TITLE
Constraint samplers bug fix and improvements

### DIFF
--- a/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler.h
+++ b/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler.h
@@ -235,7 +235,9 @@ public:
                        unsigned int max_attempts) = 0;
 
   /**
-   * \brief Returns whether or not the constraint sampler is valid or not.  To be valid, the joint model group must be available in the kinematic model.
+   * \brief Returns whether or not the constraint sampler is valid or not.
+   * To be valid, the joint model group must be available in the kinematic model and configure() must have successfully
+   * been called
    *
    * @return True if the sampler is valid, and otherwise false.
    */

--- a/constraint_samplers/src/constraint_sampler.cpp
+++ b/constraint_samplers/src/constraint_sampler.cpp
@@ -38,17 +38,13 @@
 
 constraint_samplers::ConstraintSampler::ConstraintSampler(const planning_scene::PlanningSceneConstPtr &scene, const std::string &group_name) :
   scene_(scene),
-  verbose_(false)
+  verbose_(false),
+  is_valid_(false)
 {
   jmg_ = scene->getRobotModel()->getJointModelGroup(group_name);
   if (!jmg_)
   {
     logError("A JointModelGroup should have been specified for the constraint sampler");
-    is_valid_ = false;
-  }
-  else
-  {
-    is_valid_ = true;
   }
 }
 

--- a/constraint_samplers/src/default_constraint_samplers.cpp
+++ b/constraint_samplers/src/default_constraint_samplers.cpp
@@ -491,7 +491,10 @@ bool constraint_samplers::IKConstraintSampler::sample(robot_state::RobotState &s
 bool constraint_samplers::IKConstraintSampler::sampleHelper(robot_state::RobotState &state, const robot_state::RobotState &reference_state, unsigned int max_attempts, bool project)
 {
   if (!is_valid_)
+  {
+    logWarn("IKConstraintSampler not configured, won't sample");
     return false;
+  }
 
   kinematics::KinematicsBase::IKCallbackFn adapted_ik_validity_callback;
   if (group_state_validity_callback_)

--- a/constraint_samplers/src/default_constraint_samplers.cpp
+++ b/constraint_samplers/src/default_constraint_samplers.cpp
@@ -132,7 +132,8 @@ bool constraint_samplers::JointConstraintSampler::configure(const std::vector<ki
           continue;
       }
       unbounded_.push_back(joints[i]);
-      uindex_.push_back(joints[i]->getFirstVariableIndex());
+      // Get the first variable name of this joint and find its index position in the planning group
+      uindex_.push_back(jmg_->getVariableGroupIndex(vars[0]));
     }
   values_.resize(jmg_->getVariableCount());
   is_valid_ = true;


### PR DESCRIPTION
As I'm implementing my own constraint sampler I've found the following issues:
- In the default JointConstraintSampler, if you have any unbound joints there is a bug where it accesses memory outside of it array. The mistake was that it was get the `getFirstVariableIndex()` of the joint with respect to the _robot state_ instead of the _joint model group_
- I fixed a bug where the default JointConstraintSampler will allow a planner to sample states even when it has not been properly configured. Both the default JointConstraintSampler and IKConstraintSampler use the `is_valid_` boolean to determine if the sampler has properly been setup, yet the constructor of the default ConstraintSampler set this flag to true under only one condition - that a valid joint model group was passed in. It should not do this, but instead wait until `configure()` has succeeded, otherwise a segfault will occur when `sample()` is called. I also clarified the documentation of this flag
- I added some comments I used when reading through the default constraint sampler logic
