### PR TITLE
fix bad includes after upstream catkin fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,12 +33,7 @@ pkg_check_modules(LIBFCL REQUIRED fcl)
 find_library(LIBFCL_LIBRARIES_FULL ${LIBFCL_LIBRARIES} ${LIBFCL_LIBRARY_DIRS})
 set(LIBFCL_LIBRARIES "${LIBFCL_LIBRARIES_FULL}")
 
-# This is where the version file will be generated
-set(VERSION_FILE_PATH "${CMAKE_CURRENT_BINARY_DIR}/version")
-file(MAKE_DIRECTORY "${VERSION_FILE_PATH}")
-
 set(THIS_PACKAGE_INCLUDE_DIRS 
-    ${VERSION_FILE_PATH}
     background_processing/include
     exceptions/include
     backtrace/include
@@ -125,8 +120,8 @@ string(REGEX REPLACE "^[0-9]+\\.[0-9]+\\.([0-9]+).*" "\\1" MOVEIT_VERSION_PATCH 
 set(MOVEIT_VERSION_EXTRA "Alpha")
 set(MOVEIT_VERSION "${MOVEIT_VERSION_MAJOR}.${MOVEIT_VERSION_MINOR}.${MOVEIT_VERSION_PATCH}-${MOVEIT_VERSION_EXTRA}")
 message(STATUS " *** Building MoveIt! ${MOVEIT_VERSION} ***")
-configure_file("version/version.h.in" "${VERSION_FILE_PATH}/moveit/version.h")
-install(FILES "${VERSION_FILE_PATH}/moveit/version.h" DESTINATION include/moveit)
+configure_file("version/version.h.in" "${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION}/moveit/version.h")
+install(FILES "${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION}/moveit/version.h" DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}/moveit)
 
 # If the resources package is present, the tests can be built
 set(BUILD_MOVEIT_TESTS FALSE)


### PR DESCRIPTION
This actually create crashes:
http://jenkins.ros.org/job/ros-hydro-object-recognition-tabletop_binarydeb_quantal_amd64/48/console
(because ${VERSION_FILE_PATH} is now included for install space, as it should but there was a bug in catkin)
