### PR TITLE
computeCartesianPath waypoints double-up fix

### DIFF
--- a/robot_state/src/robot_state.cpp
+++ b/robot_state/src/robot_state.cpp
@@ -1661,12 +1661,18 @@ double moveit::core::RobotState::computeCartesianPath(const JointModelGroup *gro
     if (fabs(wp_percentage_solved - 1.0) < std::numeric_limits<double>::epsilon())
     {
       percentage_solved = (double)(i + 1) / (double)waypoints.size();
-      traj.insert(traj.end(), waypoint_traj.begin(), waypoint_traj.end());
+      std::vector<RobotStatePtr>::iterator start = waypoint_traj.begin();
+      if(i > 0)
+        std::advance(start, 1);
+      traj.insert(traj.end(), start, waypoint_traj.end());
     }
     else
     {
       percentage_solved += wp_percentage_solved / (double)waypoints.size();
-      traj.insert(traj.end(), waypoint_traj.begin(), waypoint_traj.end());
+      std::vector<RobotStatePtr>::iterator start = waypoint_traj.begin();
+      if(i > 0)
+        std::advance(start, 1);
+      traj.insert(traj.end(), start, waypoint_traj.end());
       break;
     }
   }

--- a/robot_state/src/robot_state.cpp
+++ b/robot_state/src/robot_state.cpp
@@ -1662,7 +1662,7 @@ double moveit::core::RobotState::computeCartesianPath(const JointModelGroup *gro
     {
       percentage_solved = (double)(i + 1) / (double)waypoints.size();
       std::vector<RobotStatePtr>::iterator start = waypoint_traj.begin();
-      if(i > 0)
+      if(i > 0 && !waypoint_traj.empty())
         std::advance(start, 1);
       traj.insert(traj.end(), start, waypoint_traj.end());
     }
@@ -1670,7 +1670,7 @@ double moveit::core::RobotState::computeCartesianPath(const JointModelGroup *gro
     {
       percentage_solved += wp_percentage_solved / (double)waypoints.size();
       std::vector<RobotStatePtr>::iterator start = waypoint_traj.begin();
-      if(i > 0)
+      if(i > 0 && !waypoint_traj.empty())
         std::advance(start, 1);
       traj.insert(traj.end(), start, waypoint_traj.end());
       break;


### PR DESCRIPTION
computeCartesianPath appends full trajectories between waypoints when given a vector of waypoints. As trajectories include their endpoints, this leads to the combined trajectory being generated with duplicate points at waypoints, which can lead to pauses or stuttering.

This change skips the first point in trajectories generated between waypoints.
