### PR TITLE
dynamics_solver: fix crashbug

### DIFF
--- a/dynamics_solver/src/dynamics_solver.cpp
+++ b/dynamics_solver/src/dynamics_solver.cpp
@@ -128,7 +128,7 @@ DynamicsSolver::DynamicsSolver(const robot_model::RobotModelConstPtr &robot_mode
   for (std::size_t i = 0; i < joint_model_names.size(); ++i)
   {
     const urdf::Joint* ujoint = urdf_model->getJoint(joint_model_names[i]).get();
-    if (ujoint->limits)
+    if (ujoint && ujoint->limits)
       max_torques_.push_back(ujoint->limits->effort);
     else
       max_torques_.push_back(0.0);


### PR DESCRIPTION
Ignore joint that does not exist (including the virtual joint if it is part of
the group).
