### PR TITLE
Fix cartesian path

### DIFF
--- a/robot_state/src/robot_state.cpp
+++ b/robot_state/src/robot_state.cpp
@@ -1661,7 +1661,7 @@ double moveit::core::RobotState::computeCartesianPath(const JointModelGroup *gro
     if (fabs(wp_percentage_solved - 1.0) < std::numeric_limits<double>::epsilon())
     {
       unsigned int offset_index = 0;
-      if(i > 0 && waypoints.size() > 1)
+      if(i > 0 && waypoint_traj.size() > 1)
 	offset_index = 1;
       percentage_solved = (double)(i + 1) / (double)waypoints.size();
       traj.insert(traj.end(), waypoint_traj.begin()+offset_index, waypoint_traj.end());

--- a/robot_state/src/robot_state.cpp
+++ b/robot_state/src/robot_state.cpp
@@ -1660,8 +1660,11 @@ double moveit::core::RobotState::computeCartesianPath(const JointModelGroup *gro
     double wp_percentage_solved = computeCartesianPath(group, waypoint_traj, link, waypoints[i], global_reference_frame, max_step, jump_threshold, validCallback, options);
     if (fabs(wp_percentage_solved - 1.0) < std::numeric_limits<double>::epsilon())
     {
+      unsigned int offset_index = 0;
+      if(i > 0 && waypoints.size() > 1)
+	offset_index = 1;
       percentage_solved = (double)(i + 1) / (double)waypoints.size();
-      traj.insert(traj.end(), waypoint_traj.begin(), waypoint_traj.end());
+      traj.insert(traj.end(), waypoint_traj.begin()+offset_index, waypoint_traj.end());
     }
     else
     {


### PR DESCRIPTION
 fix for when compute cartesian path adds the first waypoint of an individual segment multiple times, once as the endpoint for the previous segment and once as the start point for the current segment.
