### PR TITLE
Fix compiler warnings

### DIFF
--- a/collision_detection/src/collision_octomap_filter.cpp
+++ b/collision_detection/src/collision_octomap_filter.cpp
@@ -271,7 +271,7 @@ bool sampleCloud(const octomap::point3d_list& cloud,
   bool WYVILL = true;
 
   octomap::point3d_list::const_iterator it;
-  for ( it = cloud.begin(); it != cloud.end(); it++ )
+  for ( it = cloud.begin(); it != cloud.end(); ++it )
   {
     octomath::Vector3 v = (*it);
 

--- a/collision_detection/src/world.cpp
+++ b/collision_detection/src/world.cpp
@@ -69,7 +69,7 @@ void collision_detection::World::addToObject(const std::string &id,
     return;
   }
 
-  if (!shapes.size())
+  if (shapes.empty())
     return;
 
   int action = ADD_SHAPE;

--- a/collision_detection_fcl/src/collision_common.cpp
+++ b/collision_detection_fcl/src/collision_common.cpp
@@ -743,7 +743,7 @@ void collision_detection::FCLObject::registerTo(fcl::BroadPhaseCollisionManager 
   std::vector<fcl::CollisionObject*> collision_objects(collision_objects_.size());
   for(std::size_t i = 0; i < collision_objects_.size(); ++i)
     collision_objects[i] = collision_objects_[i].get();
-  if (collision_objects.size() > 0)
+  if (!collision_objects.empty())
     manager->registerObjects(collision_objects);
 }
 

--- a/constraint_samplers/src/constraint_sampler.cpp
+++ b/constraint_samplers/src/constraint_sampler.cpp
@@ -37,9 +37,9 @@
 #include <moveit/constraint_samplers/constraint_sampler.h>
 
 constraint_samplers::ConstraintSampler::ConstraintSampler(const planning_scene::PlanningSceneConstPtr &scene, const std::string &group_name) :
+  is_valid_(false),
   scene_(scene),
-  verbose_(false),
-  is_valid_(false)
+  verbose_(false)
 {
   jmg_ = scene->getRobotModel()->getJointModelGroup(group_name);
   if (!jmg_)

--- a/distance_field/src/propagation_distance_field.cpp
+++ b/distance_field/src/propagation_distance_field.cpp
@@ -663,9 +663,9 @@ bool PropagationDistanceField::writeToStream(std::ostream& os) const
   out.push(boost::iostreams::zlib_compressor());
   out.push(os);
 
-  for(unsigned int x = 0; x < getXNumCells(); x++) {
-    for(unsigned int y = 0; y < getYNumCells(); y++) {
-      for(unsigned int z = 0; z < getZNumCells(); z+=8) {
+  for(unsigned int x = 0; x < static_cast<unsigned int>(getXNumCells()); x++) {
+    for(unsigned int y = 0; y < static_cast<unsigned int>(getYNumCells()); y++) {
+      for(unsigned int z = 0; z < static_cast<unsigned int>(getZNumCells()); z+=8) {
         std::bitset<8> bs(0);
         unsigned int zv = std::min((unsigned int)8, getZNumCells()-z);
         for(unsigned int zi = 0; zi < zv; zi++) {
@@ -731,9 +731,9 @@ bool PropagationDistanceField::readFromStream(std::istream& is)
   //std::cout << "Nums " << getXNumCells() << " " << getYNumCells() << " " << getZNumCells() << std::endl;
 
   std::vector<Eigen::Vector3i> obs_points;
-  for(unsigned int x = 0; x < getXNumCells(); x++) {
-    for(unsigned int y = 0; y < getYNumCells(); y++) {
-      for(unsigned int z = 0; z < getZNumCells(); z+=8) {
+  for(unsigned int x = 0; x < static_cast<unsigned int>(getXNumCells()); x++) {
+    for(unsigned int y = 0; y < static_cast<unsigned int>(getYNumCells()); y++) {
+      for(unsigned int z = 0; z < static_cast<unsigned int>(getZNumCells()); z+=8) {
         char inchar;
         if(!in.good()) {
           return false;

--- a/distance_field/src/propagation_distance_field.cpp
+++ b/distance_field/src/propagation_distance_field.cpp
@@ -679,6 +679,7 @@ bool PropagationDistanceField::writeToStream(std::ostream& os) const
     }
   }
   out.flush();
+  return true;
 }
 
 bool PropagationDistanceField::readFromStream(std::istream& is)
@@ -751,6 +752,7 @@ bool PropagationDistanceField::readFromStream(std::istream& is)
     }
   }
   addNewObstacleVoxels(obs_points);
+  return true;
 }
 
 }

--- a/distance_field/src/propagation_distance_field.cpp
+++ b/distance_field/src/propagation_distance_field.cpp
@@ -270,7 +270,7 @@ void PropagationDistanceField::addNewObstacleVoxels(const std::vector<Eigen::Vec
   propagatePositive();
 
   if(propagate_negative_) {
-    while(negative_stack.size() > 0)
+    while(!negative_stack.empty())
     {
       Eigen::Vector3i loc = negative_stack.back();
       negative_stack.pop_back();
@@ -356,7 +356,7 @@ void PropagationDistanceField::removeObstacleVoxels(const std::vector<Eigen::Vec
   }
 
   // Reset all neighbors who's closest point is now gone.
-  while(stack.size() > 0)
+  while(!stack.empty())
   {
     Eigen::Vector3i loc = stack.back();
     stack.pop_back();

--- a/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -469,10 +469,10 @@ public:
   virtual ~KinematicsBase() {}
 
   KinematicsBase() :
+    tip_frame_("DEPRECATED"), // help users understand why this variable might not be set
+                              // (if multiple tip frames provided, this variable will be unset)
     search_discretization_(DEFAULT_SEARCH_DISCRETIZATION),
-    default_timeout_(DEFAULT_TIMEOUT),
-    tip_frame_("DEPRECATED") // help users understand why this variable might not be set
-                             // (if multiple tip frames provided, this variable will be unset)
+    default_timeout_(DEFAULT_TIMEOUT)
   {}
 
 protected:

--- a/kinematics_metrics/src/kinematics_metrics.cpp
+++ b/kinematics_metrics/src/kinematics_metrics.cpp
@@ -188,7 +188,7 @@ bool KinematicsMetrics::getManipulability(const robot_state::RobotState &state,
     Eigen::MatrixXd jacobian = state.getJacobian(joint_model_group);
     Eigen::JacobiSVD<Eigen::MatrixXd> svdsolver(jacobian.topLeftCorner(3,jacobian.cols()));
     Eigen::MatrixXd singular_values = svdsolver.singularValues();
-    for (unsigned int i = 0; i < singular_values.rows(); ++i)
+    for (int i = 0; i < singular_values.rows(); ++i)
       logDebug("moveit.kin_metrics: Singular value: %d %f",i,singular_values(i,0));
     manipulability = penalty * singular_values.minCoeff()/singular_values.maxCoeff();
   }
@@ -197,7 +197,7 @@ bool KinematicsMetrics::getManipulability(const robot_state::RobotState &state,
     Eigen::MatrixXd jacobian = state.getJacobian(joint_model_group);
     Eigen::JacobiSVD<Eigen::MatrixXd> svdsolver(jacobian);
     Eigen::MatrixXd singular_values = svdsolver.singularValues();
-    for(unsigned int i=0; i < singular_values.rows(); ++i)
+    for(int i=0; i < singular_values.rows(); ++i)
       logDebug("moveit.kin_metrics: Singular value: %d %f",i,singular_values(i,0));
     manipulability = penalty * singular_values.minCoeff()/singular_values.maxCoeff();
   }

--- a/planning_interface/src/planning_interface.cpp
+++ b/planning_interface/src/planning_interface.cpp
@@ -85,7 +85,7 @@ void planning_interface::PlanningContext::setMotionPlanRequest(const MotionPlanR
   }
   if (request_.num_planning_attempts < 0)
     logError("The number of desired planning attempts should be positive. Assuming one attempt.");
-  request_.num_planning_attempts == std::max(1, request_.num_planning_attempts);
+  request_.num_planning_attempts = std::max(1, request_.num_planning_attempts);
 }
 
 bool planning_interface::PlannerManager::initialize(const robot_model::RobotModelConstPtr &, const std::string &)

--- a/planning_scene/src/planning_scene.cpp
+++ b/planning_scene/src/planning_scene.cpp
@@ -737,7 +737,6 @@ void planning_scene::PlanningScene::getPlanningSceneDiffMsg(moveit_msgs::Plannin
 
   if (world_diff_)
   {
-    bool do_cmap = false;
     bool do_omap = false;
     for (collision_detection::WorldDiff::const_iterator it = world_diff_->begin() ; it != world_diff_->end() ; ++it)
     {

--- a/robot_model/src/joint_model.cpp
+++ b/robot_model/src/joint_model.cpp
@@ -50,8 +50,8 @@ moveit::core::JointModel::JointModel(const std::string& name)
   , mimic_offset_(0.0)
   , passive_(false)
   , distance_factor_(1.0)
-  , joint_index_(-1)
   , first_variable_index_(-1)
+  , joint_index_(-1)
 {
 }
 

--- a/robot_model/src/joint_model_group.cpp
+++ b/robot_model/src/joint_model_group.cpp
@@ -170,7 +170,6 @@ moveit::core::JointModelGroup::JointModelGroup(const std::string& group_name,
   // that root distinct subtrees
   for (std::size_t i = 0 ; i < active_joint_model_vector_.size() ; ++i)
   {
-    bool found = false;
     // if we find that an ancestor is also in the group, then the joint is not a root
     if (!includesParent(active_joint_model_vector_[i], this))
       joint_roots_.push_back(active_joint_model_vector_[i]);

--- a/robot_model/src/robot_model.cpp
+++ b/robot_model/src/robot_model.cpp
@@ -1057,7 +1057,7 @@ const moveit::core::JointModel* moveit::core::RobotModel::getJointModel(const st
 
 const moveit::core::JointModel* moveit::core::RobotModel::getJointModel(int index) const
 {
-  if (index < 0 || index >= joint_model_vector_.size())
+  if (index < 0 || index >= static_cast<int>(joint_model_vector_.size()))
   {
     logError("Joint index '%i' out of bounds of joints in model '%s'", index, model_name_.c_str());
     return NULL;
@@ -1086,7 +1086,7 @@ const moveit::core::LinkModel* moveit::core::RobotModel::getLinkModel(const std:
 
 const moveit::core::LinkModel* moveit::core::RobotModel::getLinkModel(int index) const
 {
-  if (index < 0 || index >= link_model_vector_.size())
+  if (index < 0 || index >= static_cast<int>(link_model_vector_.size()))
   {
     logError("Link index '%i' out of bounds of links in model '%s'", index, model_name_.c_str());
     return NULL;

--- a/robot_model/src/robot_model.cpp
+++ b/robot_model/src/robot_model.cpp
@@ -258,7 +258,7 @@ void moveit::core::RobotModel::buildJointInfo()
     const std::vector<std::string> &name_order = joint_model_vector_[i]->getVariableNames();
     
     // compute index map
-    if (name_order.size() > 0)
+    if (!name_order.empty())
     {
       for (std::size_t j = 0; j < name_order.size(); ++j)
       {

--- a/robot_state/src/robot_state.cpp
+++ b/robot_state/src/robot_state.cpp
@@ -1200,6 +1200,7 @@ bool ikCallbackFnAdapter(RobotState *state, const JointModelGroup *group, const 
     error_code.val = moveit_msgs::MoveItErrorCodes::SUCCESS;
   else
     error_code.val = moveit_msgs::MoveItErrorCodes::NO_IK_SOLUTION;
+  return true;
 }
 }
 }

--- a/robot_state/src/robot_state.cpp
+++ b/robot_state/src/robot_state.cpp
@@ -1100,9 +1100,9 @@ void moveit::core::RobotState::computeVariableVelocity(const JointModelGroup *jm
   Eigen::VectorXd Sinv = S;
   static const double pinvtoler = std::numeric_limits<float>::epsilon();
   double maxsv = 0.0 ;
-  for (std::size_t i = 0; i < S.rows(); ++i)
+  for (std::size_t i = 0; i < static_cast<std::size_t>(S.rows()); ++i)
     if (fabs(S(i)) > maxsv) maxsv = fabs(S(i));
-  for (std::size_t i = 0; i < S.rows(); ++i)
+  for (std::size_t i = 0; i < static_cast<std::size_t>(S.rows()); ++i)
   {
     //Those singular values smaller than a percentage of the maximum singular value are removed
     if (fabs(S(i)) > maxsv * pinvtoler)

--- a/robot_state/src/robot_state.cpp
+++ b/robot_state/src/robot_state.cpp
@@ -471,7 +471,7 @@ void moveit::core::RobotState::updateLinkTransforms()
 void moveit::core::RobotState::updateLinkTransformsInternal(const JointModel *start)
 {  
   const std::vector<const LinkModel*> &links = start->getDescendantLinkModels();
-  if (links.size() > 0)
+  if (!links.empty())
   { 
     const LinkModel *parent = links[0]->getParentLinkModel();
     if (parent)

--- a/trajectory_processing/src/iterative_time_parameterization.cpp
+++ b/trajectory_processing/src/iterative_time_parameterization.cpp
@@ -195,7 +195,6 @@ void updateTrajectory(robot_trajectory::RobotTrajectory& rob_trajectory,
   const robot_model::JointModelGroup *group = rob_trajectory.getGroup();
   const std::vector<std::string> &vars = group->getVariableNames();
   const std::vector<int> &idx = group->getVariableIndexList();
-  const robot_model::RobotModel &rmodel = group->getParentModel();
 
   int num_points = rob_trajectory.getWayPointCount();
   

--- a/trajectory_processing/src/iterative_time_parameterization.cpp
+++ b/trajectory_processing/src/iterative_time_parameterization.cpp
@@ -183,7 +183,7 @@ void updateTrajectory(robot_trajectory::RobotTrajectory& rob_trajectory,
                       const std::vector<double>& time_diff)
 {
   // Error check
-  if (time_diff.size() < 1)
+  if (time_diff.empty())
     return;
 
   double time_sum = 0.0;

--- a/trajectory_processing/src/iterative_time_parameterization.cpp
+++ b/trajectory_processing/src/iterative_time_parameterization.cpp
@@ -435,7 +435,7 @@ void IterativeParabolicTimeParameterization::applyAccelerationConstraints(robot_
       }
     }
     //logDebug("applyAcceleration: num_updates=%i", num_updates);
-  } while (num_updates > 0 && iteration < max_iterations_);
+  } while (num_updates > 0 && iteration < static_cast<int>(max_iterations_));
 }
 
 bool IterativeParabolicTimeParameterization::computeTimeStamps(robot_trajectory::RobotTrajectory& trajectory) const


### PR DESCRIPTION
Similar to ros-planning/moveit_ros#451, but targeting moveit_core.

Most fixes are on enforcing compiler strictness and minor performance improvements. However, 4130e2b is behavior-changing. I believe it's a bugfix.
