### PR TITLE
Perform self-collision checks with padded robot.

### DIFF
--- a/planning_scene/src/planning_scene.cpp
+++ b/planning_scene/src/planning_scene.cpp
@@ -523,8 +523,8 @@ void planning_scene::PlanningScene::checkCollision(const collision_detection::Co
 
   if (!res.collision || (req.contacts && res.contacts.size() < req.max_contacts))
   {
-    // do self-collision checking with the unpadded version of the robot
-    getCollisionRobotUnpadded()->checkSelfCollision(req, res, kstate, getAllowedCollisionMatrix());
+    // do self-collision checking with the padded version of the robot
+    getCollisionRobot()->checkSelfCollision(req, res, kstate, getAllowedCollisionMatrix());
   }
 }
 
@@ -544,9 +544,9 @@ void planning_scene::PlanningScene::checkCollision(const collision_detection::Co
   // check collision with the world using the padded version
   getCollisionWorld()->checkRobotCollision(req, res, *getCollisionRobot(), kstate, acm);
 
-  // do self-collision checking with the unpadded version of the robot
+  // do self-collision checking with the padded version of the robot
   if (!res.collision || (req.contacts && res.contacts.size() < req.max_contacts))
-    getCollisionRobotUnpadded()->checkSelfCollision(req, res, kstate, acm);
+    getCollisionRobot()->checkSelfCollision(req, res, kstate, acm);
 }
 
 void planning_scene::PlanningScene::checkCollisionUnpadded(const collision_detection::CollisionRequest& req,


### PR DESCRIPTION
Self-collision checking is currently done with an unpadded robot. My expectation is that if a robot has a padding specification, it should not only be used for environment collision checks, but also for self-collision checks.

I've tested this patch on my end and it works, but I don't know to which extent it might be affecting code that actually expects self-collision checks to be unpadded.

See also @k-okada's comment on https://github.com/ros-planning/moveit_ros/issues/341#issuecomment-32701710.
