### PR TITLE
IterativeParabolicTimeParameterization now ignores virtual joints.

### DIFF
--- a/trajectory_processing/src/iterative_time_parameterization.cpp
+++ b/trajectory_processing/src/iterative_time_parameterization.cpp
@@ -449,25 +449,6 @@ bool IterativeParabolicTimeParameterization::computeTimeStamps(robot_trajectory:
     return false;
   }
 
-  // Collect the set of virtual joint names so we can ignore them.
-  std::set<std::string> virtual_joints;
-  const std::vector<srdf::Model::VirtualJoint> &vjoints =
-    trajectory.getRobotModel()->getSRDF()->getVirtualJoints();
-  for(size_t i = 0; i < vjoints.size(); i++)
-  {
-    virtual_joints.insert(vjoints[i].name_);
-  }
-
-  const std::vector<const robot_model::JointModel*> &jnt = group->getJointModels();
-  for(std::size_t i = 0 ; i < jnt.size() ; ++i)
-  {
-    if(jnt[i]->getVariableCount() > 1 && virtual_joints.count(jnt[i]->getName()) == 0)
-    {
-      logWarn("Time parametrization works for single-dof joints only");
-      return false;
-    }
-  }
-
   // this lib does not actually work properly when angles wrap around, so we need to unwind the path first
   trajectory.unwind();
 

--- a/trajectory_processing/src/iterative_time_parameterization.cpp
+++ b/trajectory_processing/src/iterative_time_parameterization.cpp
@@ -449,13 +449,24 @@ bool IterativeParabolicTimeParameterization::computeTimeStamps(robot_trajectory:
     return false;
   }
 
+  // Collect the set of virtual joint names so we can ignore them.
+  std::set<std::string> virtual_joints;
+  const std::vector<srdf::Model::VirtualJoint> &vjoints =
+    trajectory.getRobotModel()->getSRDF()->getVirtualJoints();
+  for(size_t i = 0; i < vjoints.size(); i++)
+  {
+    virtual_joints.insert(vjoints[i].name_);
+  }
+
   const std::vector<const robot_model::JointModel*> &jnt = group->getJointModels();
-  for (std::size_t i = 0 ; i < jnt.size() ; ++i)
-    if (jnt[i]->getVariableCount() > 1)
+  for(std::size_t i = 0 ; i < jnt.size() ; ++i)
+  {
+    if(jnt[i]->getVariableCount() > 1 && virtual_joints.count(jnt[i]->getName()) == 0)
     {
       logWarn("Time parametrization works for single-dof joints only");
       return false;
     }
+  }
 
   // this lib does not actually work properly when angles wrap around, so we need to unwind the path first
   trajectory.unwind();


### PR DESCRIPTION
[edit: see next comment for updated info]

When checking if all joints are single-DOF, it accepts multi-DOF joints only if they are
also virtual.

Previously it would fail on my planned trajectories which involve only single-DOF joints plus the virtual "world joint" which I needed to include in the planning group in order to visualize the plan properly.  The virtual joints don't really exist, so I think this should be fine.

I have run this with my robot model including the world joint and it seems to work fine.
