### PR TITLE
fix pick/place approach/retreat on indigo/14.04

### DIFF
--- a/robot_state/src/robot_state.cpp
+++ b/robot_state/src/robot_state.cpp
@@ -1622,7 +1622,7 @@ double moveit::core::RobotState::computeCartesianPath(const JointModelGroup *gro
   const Eigen::Affine3d &start_pose = getGlobalLinkTransform(link);
   
   //the direction can be in the local reference frame (in which case we rotate it)
-  const Eigen::Vector3d &rotated_direction = global_reference_frame ? direction : start_pose.rotation() * direction;
+  const Eigen::Vector3d rotated_direction = global_reference_frame ? direction : start_pose.rotation() * direction;
 
   //The target pose is built by applying a translation to the start pose for the desired direction and distance
   Eigen::Affine3d target_pose = start_pose;


### PR DESCRIPTION
I'm not entirely sure _why_ this is a problem, and it has no issue with a source checkout on Hydro/12.04, but as long as rotated_direction is a reference, the rotated_direction vector is always wrong with a source checkout on Indigo and Ubuntu 14.04 (all values nearly zero). Could be a change in Eigen, or the compiler I suppose. @isucan, any thoughts?
