### PR TITLE
kinematics_base: added an optional RobotState for context.

### DIFF
--- a/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -48,6 +48,7 @@ namespace moveit
 namespace core
 {
 class JointModelGroup;
+class RobotState;
 }
 }
 
@@ -198,7 +199,15 @@ public:
    * @param solution the solution vector
    * @param solution_callback A callback solution for the IK solution
    * @param error_code an error code that encodes the reason for failure or success
-   * @param lock_redundant_joints if setRedundantJoints() was previously called, keep the values of the joints marked as redundant the same as in the seed
+   * @param options container for other IK options
+   * @param context_state (optional) the context in which this request
+   *        is being made.  The position values corresponding to
+   *        joints in the current group may not match those in
+   *        ik_seed_state.  The values in ik_seed_state are the ones
+   *        to use.  This is passed just to provide the \em other
+   *        joint values, in case they are needed for context, like
+   *        with an IK solver that computes a balanced result for a
+   *        biped.
    * @return True if a valid solution was found, false otherwise
    */
   virtual bool searchPositionIK(const std::vector<geometry_msgs::Pose> &ik_poses,
@@ -208,7 +217,8 @@ public:
                                 std::vector<double> &solution,
                                 const IKCallbackFn &solution_callback,
                                 moveit_msgs::MoveItErrorCodes &error_code,
-                                const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const
+                                const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions(),
+                                const moveit::core::RobotState* context_state = NULL) const
   {
     // For IK solvers that do not support multiple poses, fall back to single pose call
     if (ik_poses.size() == 1)

--- a/robot_state/src/robot_state.cpp
+++ b/robot_state/src/robot_state.cpp
@@ -1390,7 +1390,7 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup *jmg, const Eigen
     // compute the IK solution
     std::vector<double> ik_sol;
     moveit_msgs::MoveItErrorCodes error;
-    if (solver->searchPositionIK(ik_queries, seed, timeout, consistency_limits, ik_sol, ik_callback_fn, error, options))
+    if (solver->searchPositionIK(ik_queries, seed, timeout, consistency_limits, ik_sol, ik_callback_fn, error, options, this))
     {
       std::vector<double> solution(bij.size());
       for (std::size_t i = 0 ; i < bij.size() ; ++i)


### PR DESCRIPTION
For my humanoid work, I need a way for the IK solver to know the position values of all joints, not just the ones in the group.
