### PR TITLE
Fixed bug in RevoluteJointModel::distance() giving large negative numbers.

### DIFF
--- a/robot_model/src/revolute_joint_model.cpp
+++ b/robot_model/src/revolute_joint_model.cpp
@@ -154,7 +154,7 @@ double moveit::core::RevoluteJointModel::distance(const double *values1, const d
 {
   if (continuous_)
   {
-    double d = fabs(values1[0] - values2[0]);
+    double d = fmod(fabs(values1[0] - values2[0]), 2.0 * boost::math::constants::pi<double>());
     return (d > boost::math::constants::pi<double>()) ? 2.0 * boost::math::constants::pi<double>() - d : d;
   }
   else


### PR DESCRIPTION
RevoluteJointModel::distance() was giving large negative values for a continuous joint, and upon investigation it turns out that there is nothing to enforce the continuous joint values to be between -pi and +pi or 0 and 2_pi.  The code in distance() was correct if the values *were_ constrained, so I just added an extra "fmod()" call.
