### PR TITLE
New setToRandomPositions function with custom rand num generator

### DIFF
--- a/robot_state/include/moveit/robot_state/robot_state.h
+++ b/robot_state/include/moveit/robot_state/robot_state.h
@@ -894,6 +894,10 @@ as the new values that correspond to the group */
   /** \brief Set all joints in \e group to random values.  Values will be within default bounds. */
   void setToRandomPositions(const JointModelGroup *group);
 
+  /** \brief Set all joints in \e group to random values using a specified random number generator.
+      Values will be within default bounds. */
+  void setToRandomPositions(const JointModelGroup *group, random_numbers::RandomNumberGenerator &rng);
+
   /** \brief Set all joints in \e group to random values near the value in \near.
    *  \e distance is the maximum amount each joint value will vary from the
    *  corresponding value in \e near.  \distance represents meters for

--- a/robot_state/src/robot_state.cpp
+++ b/robot_state/src/robot_state.cpp
@@ -209,6 +209,10 @@ void moveit::core::RobotState::setToRandomPositions(const JointModelGroup *group
   // we do not make calls to RobotModel for random number generation because mimic joints
   // could trigger updates outside the state of the group itself
   random_numbers::RandomNumberGenerator &rng = getRandomNumberGenerator();
+  setToRandomPositions(group, rng);
+}
+void moveit::core::RobotState::setToRandomPositions(const JointModelGroup *group, random_numbers::RandomNumberGenerator &rng)
+{
   const std::vector<const JointModel*> &joints = group->getActiveJointModels();
   for (std::size_t i = 0 ; i < joints.size() ; ++i)
     joints[i]->getVariableRandomPositions(rng, position_ + joints[i]->getFirstVariableIndex());


### PR DESCRIPTION
Added new setToRandomPositions function that allows custom random number generator to be specified

Used for benchmarking with stochastic behavior. Useful with https://github.com/ros-planning/random_numbers/pull/7
