### PR TITLE
Added getSubgroups() helper function to joint model groups

### DIFF
--- a/robot_model/include/moveit/robot_model/joint_model_group.h
+++ b/robot_model/include/moveit/robot_model/joint_model_group.h
@@ -409,6 +409,9 @@ public:
     return subgroup_names_;
   }
 
+  /** \brief Get the groups that are subsets of this one (in terms of joints set) */
+  void getSubgroups(std::vector<const JointModelGroup*>& sub_groups) const;
+
   /** \brief Check if the joints of group \e group are a subset of the joints in this group */
   bool isSubgroup(const std::string& group) const
   {

--- a/robot_model/src/joint_model_group.cpp
+++ b/robot_model/src/joint_model_group.cpp
@@ -278,6 +278,13 @@ void moveit::core::JointModelGroup::setSubgroupNames(const std::vector<std::stri
     subgroup_names_set_.insert(subgroup_names_[i]);
 }
 
+void moveit::core::JointModelGroup::getSubgroups(std::vector<const JointModelGroup*>& sub_groups) const
+{
+  sub_groups.resize(subgroup_names_.size());
+  for (std::size_t i = 0 ; i < subgroup_names_.size() ; ++i)
+    sub_groups[i] = parent_model_->getJointModelGroup(subgroup_names_[i]);
+}
+
 bool moveit::core::JointModelGroup::hasJointModel(const std::string &joint) const
 {
   return joint_model_map_.find(joint) != joint_model_map_.end();


### PR DESCRIPTION
There was a `std::string getSubGroupsNames()` but no method to get the `JointModelGroup*` pointers directly. 
