### PR TITLE
Allow setFromIK() with multiple poses to single IK solver

### DIFF
--- a/robot_state/include/moveit/robot_state/robot_state.h
+++ b/robot_state/include/moveit/robot_state/robot_state.h
@@ -619,7 +619,6 @@ as the new values that correspond to the group */
    */
   bool setToIKSolverFrame(Eigen::Affine3d &pose, const kinematics::KinematicsBaseConstPtr& solver);
 
-
   /**
    * \brief Convert the frame of reference of the pose to that same frame as the IK solver expects
    * @param pose - the input to change

--- a/robot_state/include/moveit/robot_state/robot_state.h
+++ b/robot_state/include/moveit/robot_state/robot_state.h
@@ -611,6 +611,21 @@ as the new values that correspond to the group */
   /** \brief For a given group, copy the position values of the variables that make up the group into another location, in the order that the variables are found in the group. This is not necessarily a contiguous block of memory in the RobotState itself, so we copy instead of returning a pointer.*/  
   void copyJointGroupPositions(const JointModelGroup *group, Eigen::VectorXd& values) const;
 
+  /**
+   * \brief Convert the frame of reference of the pose to that same frame as the IK solver expects
+   * @param pose - the input to change
+   * @param solver - a kin solver whose base frame is important to us
+   * @return true if no error
+   */
+  bool setToIKSolverFrame(Eigen::Affine3d &pose, const kinematics::KinematicsBaseConstPtr& solver);
+
+  /**
+   * \brief Convert an Eigen pose to a geometry_msgs pose
+   * @param pose - input
+   * @param pose_msg - output
+   */
+  void poseToMsg(const Eigen::Affine3d &pose, geometry_msgs::Pose &pose_msg);
+
   /** \brief If the group this state corresponds to is a chain and a solver is available, then the joint values can be set by computing inverse kinematics.
       The pose is assumed to be in the reference frame of the kinematic model. Returns true on success.
       @param pose The pose the last link in the chain needs to achieve
@@ -710,7 +725,24 @@ as the new values that correspond to the group */
                  unsigned int attempts = 0, double timeout = 0.0,
                  const GroupStateValidityCallbackFn &constraint = GroupStateValidityCallbackFn(),
                  const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions());
-  
+
+  /**
+      \brief setFromIK for multiple poses and tips (end effectors) when no solver exists for the jmg that can solver for
+      non-chain kinematics. In this case, we divide the group into subgroups and do IK solving individually
+      @param poses The poses the last link in each chain needs to achieve
+      @param tips The names of the frames for which IK is attempted.
+      @param consistency_limits This specifies the desired distance between the solution and the seed state
+      @param attempts The number of times IK is attempted
+      @param timeout The timeout passed to the kinematics solver on each attempt
+      @param constraint A state validity constraint to be required for IK solutions */
+  bool setFromIKSubgroups(const JointModelGroup *group,
+                 const EigenSTL::vector_Affine3d &poses,
+                 const std::vector<std::string> &tips,
+                 const std::vector<std::vector<double> > &consistency_limits,
+                 unsigned int attempts = 0, double timeout = 0.0,
+                 const GroupStateValidityCallbackFn &constraint = GroupStateValidityCallbackFn(),
+                 const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions());
+
   /** \brief Set the joint values from a cartesian velocity applied during a time dt
    * @param group the group of joints this function operates on
    * @param twist a cartesian velocity on the 'tip' frame

--- a/robot_state/include/moveit/robot_state/robot_state.h
+++ b/robot_state/include/moveit/robot_state/robot_state.h
@@ -619,6 +619,15 @@ as the new values that correspond to the group */
    */
   bool setToIKSolverFrame(Eigen::Affine3d &pose, const kinematics::KinematicsBaseConstPtr& solver);
 
+
+  /**
+   * \brief Convert the frame of reference of the pose to that same frame as the IK solver expects
+   * @param pose - the input to change
+   * @param ik_frame - the name of frame of reference of base of ik solver
+   * @return true if no error
+   */
+  bool setToIKSolverFrame(Eigen::Affine3d &pose, const std::string &ik_frame);
+
   /**
    * \brief Convert an Eigen pose to a geometry_msgs pose
    * @param pose - input

--- a/robot_state/include/moveit/robot_state/robot_state.h
+++ b/robot_state/include/moveit/robot_state/robot_state.h
@@ -627,13 +627,6 @@ as the new values that correspond to the group */
    */
   bool setToIKSolverFrame(Eigen::Affine3d &pose, const std::string &ik_frame);
 
-  /**
-   * \brief Convert an Eigen pose to a geometry_msgs pose
-   * @param pose - input
-   * @param pose_msg - output
-   */
-  void poseToMsg(const Eigen::Affine3d &pose, geometry_msgs::Pose &pose_msg);
-
   /** \brief If the group this state corresponds to is a chain and a solver is available, then the joint values can be set by computing inverse kinematics.
       The pose is assumed to be in the reference frame of the kinematic model. Returns true on success.
       @param pose The pose the last link in the chain needs to achieve

--- a/robot_state/include/moveit/robot_state/robot_state.h
+++ b/robot_state/include/moveit/robot_state/robot_state.h
@@ -935,6 +935,10 @@ as the new values that correspond to the group */
   /** \brief Set all joints in \e group to random values.  Values will be within default bounds. */
   void setToRandomPositions(const JointModelGroup *group);
 
+  /** \brief Set all joints in \e group to random values using a specified random number generator.
+      Values will be within default bounds. */
+  void setToRandomPositions(const JointModelGroup *group, random_numbers::RandomNumberGenerator &rng);
+
   /** \brief Set all joints in \e group to random values near the value in \near.
    *  \e distance is the maximum amount each joint value will vary from the
    *  corresponding value in \e near.  \distance represents meters for

--- a/robot_state/src/robot_state.cpp
+++ b/robot_state/src/robot_state.cpp
@@ -1228,21 +1228,6 @@ bool moveit::core::RobotState::setToIKSolverFrame(Eigen::Affine3d &pose, const s
   return true;
 }
 
-void moveit::core::RobotState::poseToMsg(const Eigen::Affine3d &pose, geometry_msgs::Pose &pose_msg)
-{
-  // Convert Eigen pose to geometry_msgs pose
-  Eigen::Quaterniond quat(pose.rotation());
-  Eigen::Vector3d point(pose.translation());
-
-  pose_msg.position.x = point.x();
-  pose_msg.position.y = point.y();
-  pose_msg.position.z = point.z();
-  pose_msg.orientation.x = quat.x();
-  pose_msg.orientation.y = quat.y();
-  pose_msg.orientation.z = quat.z();
-  pose_msg.orientation.w = quat.w();
-}
-
 bool moveit::core::RobotState::setFromIK(const JointModelGroup *jmg, const Eigen::Affine3d &pose_in, const std::string &tip_in,
                                          const std::vector<double> &consistency_limits_in, unsigned int attempts, double timeout,
                                          const GroupStateValidityCallbackFn &constraint, const kinematics::KinematicsQueryOptions &options)
@@ -1418,7 +1403,7 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup *jmg, const Eigen
 
     // Convert Eigen pose to geometry_msgs pose
     geometry_msgs::Pose ik_query;
-    poseToMsg(pose, ik_query);
+    tf::poseEigenToMsg(pose, ik_query);
 
     // Save into vectors
     ik_queries[tip_id] = ik_query;
@@ -1447,7 +1432,7 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup *jmg, const Eigen
 
     // Convert Eigen pose to geometry_msgs pose
     geometry_msgs::Pose ik_query;
-    poseToMsg(current_pose, ik_query);
+    tf::poseEigenToMsg(current_pose, ik_query);
 
     // Save into vectors - but this needs to be ordered in the same order as the IK solver expects its tip frames
     ik_queries[tip_id] = ik_query;

--- a/robot_state/src/robot_state.cpp
+++ b/robot_state/src/robot_state.cpp
@@ -1324,7 +1324,7 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup *jmg, const Eigen
       consistency_limit_sets.size());
     return false;
   }
-  else if (!consistency_limit_sets.size() == 1)
+  else if (consistency_limit_sets.size() == 1)
     consistency_limits = consistency_limit_sets[0];
 
   const std::vector<std::string> &solver_tip_frames = solver->getTipFrames();

--- a/robot_state/src/robot_state.cpp
+++ b/robot_state/src/robot_state.cpp
@@ -1276,7 +1276,7 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup *jmg, const Eigen
   // Error check
   if (poses_in.size() != tips_in.size())
   {
-    logError("Number of poses must be the same as number of tips");
+    logError("moveit.robot_state: Number of poses must be the same as number of tips");
     return false;
   }
 
@@ -1295,7 +1295,7 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup *jmg, const Eigen
     std::string error_msg;
     if(!solver->supportsGroup(jmg, &error_msg))
     {
-      logError("Kinematics solver %s does not support joint group %s.  Error: %s",
+      logError("moveit.robot_state: Kinematics solver %s does not support joint group %s.  Error: %s",
         typeid(*solver).name(), jmg->getName().c_str(), error_msg.c_str());
       valid_solver = false;
     }
@@ -1311,7 +1311,7 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup *jmg, const Eigen
     }
     else
     {
-      logError("No kinematics solver instantiated for group '%s'", jmg->getName().c_str());
+      logError("moveit.robot_state: No kinematics solver instantiated for group '%s'", jmg->getName().c_str());
       return false;
     }
   }
@@ -1320,7 +1320,7 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup *jmg, const Eigen
   std::vector<double> consistency_limits;
   if (consistency_limit_sets.size() > 1)
   {
-    logError("An invalid number (%d) of sets of consistency limits have been passed in for a setFromIK request that is being solved by a single IK solver",
+    logError("moveit.robot_state: Invalid number (%d) of sets of consistency limits for a setFromIK request that is being solved by a single IK solver",
       consistency_limit_sets.size());
     return false;
   }
@@ -1361,7 +1361,6 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup *jmg, const Eigen
 
       // check if the tip frame can be transformed via fixed transforms to the frame known to the IK solver
       std::string tip_frame = solver_tip_frames[tip_id];
-      logDebug("moveit.robot_state: checking solver tip frame %s against request tip frame %s", tip_frame.c_str(), tip.c_str());
 
       // remove the frame '/' if there is one, so we can avoid calling Transforms::sameFrame() which may copy strings more often that we need to
       if (!tip_frame.empty() && tip_frame[0] == '/')
@@ -1375,7 +1374,7 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup *jmg, const Eigen
           const EigenSTL::vector_Affine3d &ab_trans = ab->getFixedTransforms();
           if (ab_trans.size() != 1)
           {
-            logError("Cannot use an attached body with multiple geometries as a reference frame.");
+            logError("moveit.robot_state: Cannot use an attached body with multiple geometries as a reference frame.");
             return false;
           }
           tip = ab->getAttachedLinkName();
@@ -1410,7 +1409,7 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup *jmg, const Eigen
     // Make sure one of the tip frames worked
     if (!found_valid_frame)
     {
-      logError("Cannot compute IK for tip reference frame '%s'", tip.c_str());
+      logError("moveit.robot_state: Cannot compute IK for tip reference frame '%s'", tip.c_str());
       return false;
     }
 
@@ -1488,7 +1487,7 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup *jmg, const Eigen
     }
     else
     {
-      logDebug("Rerunning IK solver with random joint positions");
+      logDebug("moveit.robot_state: Rerunning IK solver with random joint positions");
 
       // sample a random seed
       random_numbers::RandomNumberGenerator &rng = getRandomNumberGenerator();
@@ -1532,28 +1531,23 @@ bool moveit::core::RobotState::setFromIKSubgroups(const JointModelGroup *jmg, co
   // Assume we have already ran setFromIK() and those checks
 
   // Get containing subgroups
-  const std::vector<std::string>& sub_group_names = jmg->getSubgroupNames();
-  std::vector<const JointModelGroup*> sub_groups(sub_group_names.size());
-  for (std::size_t i = 0 ; i < sub_group_names.size() ; ++i)
-  {
-    logError("Subgroup found: %s", sub_group_names[i].c_str());
-    sub_groups[i] = robot_model_->getJointModelGroup(sub_group_names[i]);
-  }
+  std::vector<const JointModelGroup*> sub_groups;
+  jmg->getSubgroups(sub_groups);
 
   // Error check
-  if (poses_in.size() != sub_group_names.size())
+  if (poses_in.size() != sub_groups.size())
   {
     logError("Number of poses must be the same as number of sub-groups");
     return false;
   }
 
-  if (tips_in.size() != sub_group_names.size())
+  if (tips_in.size() != sub_groups.size())
   {
     logError("Number of tip names must be the same as number of sub-groups");
     return false;
   }
 
-  if (!consistency_limits.empty() && consistency_limits.size() != sub_group_names.size())
+  if (!consistency_limits.empty() && consistency_limits.size() != sub_groups.size())
   {
     logError("Number of consistency limit vectors must be the same as number of sub-groups");
     return false;
@@ -1575,7 +1569,7 @@ bool moveit::core::RobotState::setFromIKSubgroups(const JointModelGroup *jmg, co
     kinematics::KinematicsBaseConstPtr solver = sub_groups[i]->getSolverInstance();
     if (!solver)
     {
-      logError("Could not find solver for group '%s'", sub_group_names[i].c_str());
+      logError("Could not find solver for group '%s'", sub_groups[i]->getName().c_str());
       return false;
     }
     solvers.push_back(solver);

--- a/robot_state/src/robot_state.cpp
+++ b/robot_state/src/robot_state.cpp
@@ -209,6 +209,10 @@ void moveit::core::RobotState::setToRandomPositions(const JointModelGroup *group
   // we do not make calls to RobotModel for random number generation because mimic joints
   // could trigger updates outside the state of the group itself
   random_numbers::RandomNumberGenerator &rng = getRandomNumberGenerator();
+  setToRandomPositions(group, rng);
+}
+void moveit::core::RobotState::setToRandomPositions(const JointModelGroup *group, random_numbers::RandomNumberGenerator &rng)
+{
   const std::vector<const JointModel*> &joints = group->getActiveJointModels();
   for (std::size_t i = 0 ; i < joints.size() ; ++i)
     joints[i]->getVariableRandomPositions(rng, position_ + joints[i]->getFirstVariableIndex());

--- a/robot_state/src/robot_state.cpp
+++ b/robot_state/src/robot_state.cpp
@@ -1212,8 +1212,7 @@ bool ikCallbackFnAdapter(RobotState *state, const JointModelGroup *group, const 
 
 bool moveit::core::RobotState::setToIKSolverFrame(Eigen::Affine3d &pose, const kinematics::KinematicsBaseConstPtr& solver)
 {
-  const std::string &ik_frame = solver->getBaseFrame();
-  return setToIKSolverFrame( pose, ik_frame );
+  return setToIKSolverFrame( pose, solver->getBaseFrame() );
 }
 
 bool moveit::core::RobotState::setToIKSolverFrame(Eigen::Affine3d &pose, const std::string &ik_frame)
@@ -1464,15 +1463,15 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup *jmg, const Eigen
 
   bool first_seed = true;
   std::vector<double> initial_values;
-  copyJointGroupPositions(jmg, initial_values);
   for (unsigned int st = 0 ; st < attempts ; ++st)
   {
     std::vector<double> seed(bij.size());
 
-    // the first seed is the initial state
+    // the first seed is the current robot state joint values
     if (first_seed)
     {
       first_seed = false;
+      copyJointGroupPositions(jmg, initial_values);
       for (std::size_t i = 0 ; i < bij.size() ; ++i)
         seed[i] = initial_values[bij[i]];
     }
@@ -1491,6 +1490,7 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup *jmg, const Eigen
       {
         std::vector<unsigned int> red_joints;
         solver->getRedundantJoints(red_joints);
+        copyJointGroupPositions(jmg, initial_values);
         for(std::size_t i = 0 ; i < red_joints.size(); ++i)
           seed[red_joints[i]] = initial_values[bij[red_joints[i]]];
       }

--- a/robot_state/src/robot_state.cpp
+++ b/robot_state/src/robot_state.cpp
@@ -1208,8 +1208,13 @@ bool ikCallbackFnAdapter(RobotState *state, const JointModelGroup *group, const 
 
 bool moveit::core::RobotState::setToIKSolverFrame(Eigen::Affine3d &pose, const kinematics::KinematicsBaseConstPtr& solver)
 {
-  // bring the pose to the frame of the IK solver
   const std::string &ik_frame = solver->getBaseFrame();
+  return setToIKSolverFrame( pose, ik_frame );
+}
+
+bool moveit::core::RobotState::setToIKSolverFrame(Eigen::Affine3d &pose, const std::string &ik_frame)
+{
+  // Bring the pose to the frame of the IK solver
   if (!Transforms::sameFrame(ik_frame, robot_model_->getModelFrame()))
   {
     const LinkModel *lm = getLinkModel((!ik_frame.empty() && ik_frame[0] == '/') ? ik_frame.substr(1) : ik_frame);

--- a/robot_state/src/robot_state.cpp
+++ b/robot_state/src/robot_state.cpp
@@ -1248,8 +1248,6 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup *jmg, const Eigen
                                          const std::vector<double> &consistency_limits_in, unsigned int attempts, double timeout,
                                          const GroupStateValidityCallbackFn &constraint, const kinematics::KinematicsQueryOptions &options)
 {
-  std::cout << "First tip is " << tip_in << std::endl;
-
   // Convert from single pose and tip to vectors
   EigenSTL::vector_Affine3d poses;
   poses.push_back(pose_in);
@@ -1320,8 +1318,6 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup *jmg, const Eigen
   }
 
   const std::vector<std::string> &solver_tip_frames = solver->getTipFrames();
-  std::cout << "Solver tip frames: " << std::endl;
-  std::copy(solver_tip_frames.begin(), solver_tip_frames.end(), std::ostream_iterator<std::string>(std::cout, "\n"));
 
   // Track which possible tips frames we have filled in so far
   std::vector<bool> tip_frames_used (solver_tip_frames.size(), false);
@@ -1419,9 +1415,6 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup *jmg, const Eigen
     ik_queries[tip_id] = ik_query;
   } // end for poses_in
 
-  std::cout << "DEBUGGING TIP FRAMES AND POSES " << std::endl;
-  std::copy(tip_frames_used.begin(), tip_frames_used.end(), std::ostream_iterator<bool>(std::cout, "\n"));
-
   // Create poses for all remaining tips a solver expects, even if not passed into this function
   for (std::size_t tip_id = 0; tip_id < solver_tip_frames.size(); ++tip_id)
   {
@@ -1431,8 +1424,6 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup *jmg, const Eigen
 
     // Process this tip
     std::string tip_frame = solver_tip_frames[tip_id];
-
-    std::cout << "Getting extra pose for:  " << tip_frame << " of index " << tip_id << std::endl;
 
     // remove the frame '/' if there is one, so we can avoid calling Transforms::sameFrame() which may copy strings more often that we need to
     if (!tip_frame.empty() && tip_frame[0] == '/')
@@ -1454,11 +1445,6 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup *jmg, const Eigen
 
     // Remove that tip from the list of available tip frames because each can only have one pose
     tip_frames_used[tip_id] = true;
-  }
-
-  for (std::size_t i = 0; i < ik_queries.size(); ++i)
-  {
-    std::cout << "XYZ value of pose  " << i << " is: " << ik_queries[i].position.x << "\t" << ik_queries[i].position.y << "\t" << ik_queries[i].position.z << std::endl;
   }
 
   // if no timeout has been specified, use the default one
@@ -1492,6 +1478,8 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup *jmg, const Eigen
     }
     else
     {
+      logDebug("Rerunning IK solver with random joint positions");
+
       // sample a random seed
       random_numbers::RandomNumberGenerator &rng = getRandomNumberGenerator();
       std::vector<double> random_values;


### PR DESCRIPTION
Allows a call to setFromIK() that has multiple tips and desired poses to send them all to the same IK solver, if that solver allows it. If no solver exists for the current planning group or that solver does not support non-chain kinematics, the previous MoveIt! behavior is maintained whereby it looks for subgroups that are chains that have their own IK solvers and calls them individually.

This is a follow up of https://github.com/ros-planning/moveit_core/pull/149
### Minor Changes

Reduced duplicate code by moving two common code snippets into their own functions:
- Created new helper function for changing a pose to the base frame of an IK solver
- Created new helper function for converting a Eigen pose to a geometry_msgs pose

Contains outstanding PR:
https://github.com/ros-planning/moveit_core/pull/177
