### PR TITLE
Added ability to return used planning context in planning pipeline

### DIFF
--- a/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
+++ b/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
@@ -32,7 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Author: Ioan Sucan */
+/* Author: Ioan Sucan, Dave Coleman */
 
 #ifndef MOVEIT_PLANNING_REQUEST_ADAPTER_PLANNING_REQUEST_ADAPTER_
 #define MOVEIT_PLANNING_REQUEST_ADAPTER_PLANNING_REQUEST_ADAPTER_
@@ -41,7 +41,12 @@
 #include <moveit/planning_scene/planning_scene.h>
 #include <boost/function.hpp>
 
-/** \brief Generic interface to adapting motion planning requests */
+/** \brief Generic interface to adapting motion planning requests
+ *
+ *  The PlannRequestAdapter class is both the class used for all the adapters, as well as a
+ *  custom version used to wrap a traditional motion planner into looking like an adapter
+ *
+ */
 namespace planning_request_adapter
 {
 
@@ -66,13 +71,15 @@ public:
   bool adaptAndPlan(const planning_interface::PlannerManagerPtr &planner,
                     const planning_scene::PlanningSceneConstPtr& planning_scene,
                     const planning_interface::MotionPlanRequest &req,
-                    planning_interface::MotionPlanResponse &res) const;
+                    planning_interface::MotionPlanResponse &res,
+                    planning_interface::PlanningContextPtr &context) const;
 
   bool adaptAndPlan(const planning_interface::PlannerManagerPtr &planner,
                     const planning_scene::PlanningSceneConstPtr& planning_scene,
                     const planning_interface::MotionPlanRequest &req,
                     planning_interface::MotionPlanResponse &res,
-                    std::vector<std::size_t> &added_path_index) const;
+                    std::vector<std::size_t> &added_path_index,
+                    planning_interface::PlanningContextPtr &context) const;
 
   /** \brief Adapt the planning request if needed, call the planner
       function \e planner and update the planning response if
@@ -83,7 +90,8 @@ public:
                             const planning_scene::PlanningSceneConstPtr& planning_scene,
                             const planning_interface::MotionPlanRequest &req,
                             planning_interface::MotionPlanResponse &res,
-                            std::vector<std::size_t> &added_path_index) const = 0;
+                            std::vector<std::size_t> &added_path_index,
+                            planning_interface::PlanningContextPtr &context) const = 0;
 
 };
 
@@ -113,6 +121,17 @@ public:
                     const planning_interface::MotionPlanRequest &req,
                     planning_interface::MotionPlanResponse &res,
                     std::vector<std::size_t> &added_path_index) const;
+
+  /**
+   * \brief This is the main starting point of the planning request pipeline. The passed in 'planner' in this function is the actual
+   *        motion planning algorithm. It is called last, however, after all the provided adapters are first called in a chain
+   */
+  bool adaptAndPlan(const planning_interface::PlannerManagerPtr &planner,
+                    const planning_scene::PlanningSceneConstPtr& planning_scene,
+                    const planning_interface::MotionPlanRequest &req,
+                    planning_interface::MotionPlanResponse &res,
+                    std::vector<std::size_t> &added_path_index,
+                    planning_interface::PlanningContextPtr &context) const;
 
 private:
   std::vector<PlanningRequestAdapterConstPtr> adapters_;

--- a/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
+++ b/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
@@ -43,7 +43,7 @@
 
 /** \brief Generic interface to adapting motion planning requests
  *
- *  The PlannRequestAdapter class is both the class used for all the adapters, as well as a
+ *  The PlanningRequestAdapter class is both the class used for all the adapters, as well as a
  *  custom version used to wrap a traditional motion planner into looking like an adapter
  *
  */

--- a/planning_request_adapter/src/planning_request_adapter.cpp
+++ b/planning_request_adapter/src/planning_request_adapter.cpp
@@ -166,9 +166,8 @@ bool planning_request_adapter::PlanningRequestAdapterChain::adaptAndPlan(const p
                                                                          planning_interface::MotionPlanResponse &res,
                                                                          std::vector<std::size_t> &added_path_index) const
 {
-  std::vector<std::size_t> dummy;
   planning_interface::PlanningContextPtr context;
-  return adaptAndPlan(planner, planning_scene, req, res, dummy, context);
+  return adaptAndPlan(planner, planning_scene, req, res, added_path_index, context);
 }
 
 bool planning_request_adapter::PlanningRequestAdapterChain::adaptAndPlan(const planning_interface::PlannerManagerPtr &planner,

--- a/planning_request_adapter/src/planning_request_adapter.cpp
+++ b/planning_request_adapter/src/planning_request_adapter.cpp
@@ -32,7 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Author: Ioan Sucan */
+/* Author: Ioan Sucan, Dave Coleman */
 
 #include <moveit/planning_request_adapter/planning_request_adapter.h>
 #include <boost/bind.hpp>
@@ -47,9 +47,10 @@ namespace
 bool callPlannerInterfaceSolve(const planning_interface::PlannerManager *planner,
                                const planning_scene::PlanningSceneConstPtr& planning_scene,
                                const planning_interface::MotionPlanRequest &req,
-                               planning_interface::MotionPlanResponse &res)
+                               planning_interface::MotionPlanResponse &res,
+                               planning_interface::PlanningContextPtr &context)
 {
-  planning_interface::PlanningContextPtr context = planner->getPlanningContext(planning_scene, req, res.error_code_);
+  context = planner->getPlanningContext(planning_scene, req, res.error_code_);
   if (context)
     return context->solve(res);
   else
@@ -62,18 +63,21 @@ bool planning_request_adapter::PlanningRequestAdapter::adaptAndPlan(const planni
                                                                     const planning_scene::PlanningSceneConstPtr& planning_scene,
                                                                     const planning_interface::MotionPlanRequest &req,
                                                                     planning_interface::MotionPlanResponse &res,
-                                                                    std::vector<std::size_t> &added_path_index) const
+                                                                    std::vector<std::size_t> &added_path_index,
+                                                                    planning_interface::PlanningContextPtr &context) const
 {
-  return adaptAndPlan(boost::bind(&callPlannerInterfaceSolve, planner.get(), _1, _2, _3), planning_scene, req, res, added_path_index);
+  return adaptAndPlan(boost::bind(&callPlannerInterfaceSolve, planner.get(), _1, _2, _3, boost::ref(context)), planning_scene, req, res,
+                      added_path_index, context);
 }
 
 bool planning_request_adapter::PlanningRequestAdapter::adaptAndPlan(const planning_interface::PlannerManagerPtr &planner,
                                                                     const planning_scene::PlanningSceneConstPtr& planning_scene,
                                                                     const planning_interface::MotionPlanRequest &req,
-                                                                    planning_interface::MotionPlanResponse &res) const
+                                                                    planning_interface::MotionPlanResponse &res,
+                                                                    planning_interface::PlanningContextPtr &context) const
 {
   std::vector<std::size_t> dummy;
-  return adaptAndPlan(planner, planning_scene, req, res, dummy);
+  return adaptAndPlan(planner, planning_scene, req, res, dummy, context);
 }
 
 namespace planning_request_adapter
@@ -84,41 +88,50 @@ namespace
 
 // boost bind is not happy with overloading, so we add intermediate function objects
 
-bool callAdapter1(const PlanningRequestAdapter *adapter,
+/**
+ * \brief This is the last adapter function called in the chain, and directly calls the actual motion planner after the
+ *        last adapter is called
+ */
+bool callFinalAdapter(const PlanningRequestAdapter *adapter,
                   const planning_interface::PlannerManagerPtr &planner,
                   const planning_scene::PlanningSceneConstPtr& planning_scene,
                   const planning_interface::MotionPlanRequest &req,
                   planning_interface::MotionPlanResponse &res,
-                  std::vector<std::size_t> &added_path_index)
+                  std::vector<std::size_t> &added_path_index,
+                  planning_interface::PlanningContextPtr &context)
 {
   try
   {
-    return adapter->adaptAndPlan(planner, planning_scene, req, res, added_path_index);
+    return adapter->adaptAndPlan(planner, planning_scene, req, res, added_path_index, context);
   }
   catch(std::runtime_error &ex)
   {
     logError("Exception caught executing adapter '%s': %s", adapter->getDescription().c_str(), ex.what());
     added_path_index.clear();
-    return callPlannerInterfaceSolve(planner.get(), planning_scene, req, res);
+    return callPlannerInterfaceSolve(planner.get(), planning_scene, req, res, context);
   }
   catch(...)
   {
     logError("Exception caught executing adapter '%s'", adapter->getDescription().c_str());
     added_path_index.clear();
-    return callPlannerInterfaceSolve(planner.get(), planning_scene, req, res);
+    return callPlannerInterfaceSolve(planner.get(), planning_scene, req, res, context);
   }
 }
 
-bool callAdapter2(const PlanningRequestAdapter *adapter,
-                  const PlanningRequestAdapter::PlannerFn &planner,
-                  const planning_scene::PlanningSceneConstPtr& planning_scene,
-                  const planning_interface::MotionPlanRequest &req,
-                  planning_interface::MotionPlanResponse &res,
-                  std::vector<std::size_t> &added_path_index)
+/**
+ * \brief This is an adapter function that is not the final one. If an adapter fails, it continues to the next adapter
+ */
+bool callNextAdapter(const PlanningRequestAdapter *adapter,
+                     const PlanningRequestAdapter::PlannerFn &planner,
+                     const planning_scene::PlanningSceneConstPtr& planning_scene,
+                     const planning_interface::MotionPlanRequest &req,
+                     planning_interface::MotionPlanResponse &res,
+                     std::vector<std::size_t> &added_path_index,
+                     planning_interface::PlanningContextPtr &context)
 {
   try
   {
-    return adapter->adaptAndPlan(planner, planning_scene, req, res, added_path_index);
+    return adapter->adaptAndPlan(planner, planning_scene, req, res, added_path_index, context);
   }
   catch(std::runtime_error &ex)
   {
@@ -153,22 +166,37 @@ bool planning_request_adapter::PlanningRequestAdapterChain::adaptAndPlan(const p
                                                                          planning_interface::MotionPlanResponse &res,
                                                                          std::vector<std::size_t> &added_path_index) const
 {
+  std::vector<std::size_t> dummy;
+  planning_interface::PlanningContextPtr context;
+  return adaptAndPlan(planner, planning_scene, req, res, dummy, context);
+}
+
+bool planning_request_adapter::PlanningRequestAdapterChain::adaptAndPlan(const planning_interface::PlannerManagerPtr &planner,
+                                                                         const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                                                         const planning_interface::MotionPlanRequest &req,
+                                                                         planning_interface::MotionPlanResponse &res,
+                                                                         std::vector<std::size_t> &added_path_index,
+                                                                         planning_interface::PlanningContextPtr &context) const
+{
   // if there are no adapters, run the planner directly
   if (adapters_.empty())
   {
     added_path_index.clear();
-    return callPlannerInterfaceSolve(planner.get(), planning_scene, req, res);
+    return callPlannerInterfaceSolve(planner.get(), planning_scene, req, res, context);
   }
   else
   {
     // the index values added by each adapter
     std::vector<std::vector<std::size_t> > added_path_index_each(adapters_.size());
 
+    // Turn the motion planner (e.g. OMPL) into an 'adapter' for the purposes of our adapter chain
+    PlanningRequestAdapter::PlannerFn fn = boost::bind(&callFinalAdapter, adapters_.back().get(), planner, _1, _2, _3,
+                                                       boost::ref(added_path_index_each.back()), boost::ref(context));
+
     // if there are adapters, construct a function pointer for each, in order,
     // so that in the end we have a nested sequence of function pointers that call the adapters in the correct order.
-    PlanningRequestAdapter::PlannerFn fn = boost::bind(&callAdapter1, adapters_.back().get(), planner, _1, _2, _3, boost::ref(added_path_index_each.back()));
     for (int i = adapters_.size() - 2 ; i >= 0 ; --i)
-      fn = boost::bind(&callAdapter2, adapters_[i].get(), fn, _1, _2, _3, boost::ref(added_path_index_each[i]));
+      fn = boost::bind(&callNextAdapter, adapters_[i].get(), fn, _1, _2, _3, boost::ref(added_path_index_each[i]), context);
     bool result = fn(planning_scene, req, res);
     added_path_index.clear();
 


### PR DESCRIPTION
This adds a new feature to the planning request adapter chains that tracks the used planning context throughout as the various adapters call each other in succession. It allows one to pass in a context pointer and when the chain returns it keeps the planning context in existence for further usage and analysis. I'm using this to allow me to access the OMPL SimpleSetup class from within the planning pipeline, so that I can call some custom functions on it that I need.

This change also requires the planning adapters to be slightly modified to accept the context in their function headers.

Finally, I renamed two functions to improve clarity and added some inline documentation.
