### PR TITLE
Documentation and made function public

### DIFF
--- a/robot_state/include/moveit/robot_state/robot_state.h
+++ b/robot_state/include/moveit/robot_state/robot_state.h
@@ -1306,6 +1306,8 @@ as the new values that correspond to the group */
   void printStateInfo(std::ostream &out) const;
   
   void printTransforms(std::ostream &out) const;
+
+  void printTransform(const Eigen::Affine3d &transform, std::ostream &out) const;
   
   void printDirtyInfo(std::ostream &out) const;
   
@@ -1361,7 +1363,6 @@ private:
   
   void getMissingKeys(const std::map<std::string, double> &variable_map, std::vector<std::string> &missing_variables) const;
   void getStateTreeJointString(std::ostream& ss, const JointModel* jm, const std::string& pfx0, bool last) const;
-  void printTransform(const Eigen::Affine3d &transform, std::ostream &out) const;
 
   /** \brief This function is only called in debug mode */
   bool checkJointTransforms(const JointModel *joint) const;

--- a/robot_state/src/robot_state.cpp
+++ b/robot_state/src/robot_state.cpp
@@ -564,7 +564,7 @@ void moveit::core::RobotState::updateStateWithLinkAt(const LinkModel *link, cons
         if (cj[i] != child_link->getParentJointModel())
           updateLinkTransformsInternal(cj[i]);
     }
-    // update the root joint of the model to match (as best as possible given #DOF) the transfor we wish to obtain for the root link.
+    // update the root joint of the model to match (as best as possible given #DOF) the transform we wish to obtain for the root link.
     // but I am disabling this code, since I do not think this function should modify variable values.
     //    parent_link->getParentJointModel()->computeVariableValues(global_link_transforms_[parent_link->getLinkIndex()],
     //                                                              position_ + parent_link->getParentJointModel()->getFirstVariableIndex());

--- a/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
+++ b/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
@@ -132,11 +132,21 @@ public:
     return waypoints_.empty();
   }
 
+  /**
+   * \brief Add a point to the trajectory
+   * \param state - current robot state
+   * \param dt - duration from previous
+   */
   void addSuffixWayPoint(const robot_state::RobotState &state, double dt)
   {
     addSuffixWayPoint(robot_state::RobotStatePtr(new robot_state::RobotState(state)), dt);
   }
 
+  /**
+   * \brief Add a point to the trajectory
+   * \param state - current robot state
+   * \param dt - duration from previous
+   */
   void addSuffixWayPoint(const robot_state::RobotStatePtr &state, double dt)
   {
     state->update();


### PR DESCRIPTION
Made `printTransform` function public so that other MoveIt code can easily use this helper
