### PR TITLE
Change PlanningScene constructor to RobotModelConstPtr

### DIFF
--- a/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -88,7 +88,7 @@ class PlanningScene : private boost::noncopyable,
 public:
 
   /** \brief construct using an existing RobotModel */
-  PlanningScene(const robot_model::RobotModelPtr &robot_model,
+  PlanningScene(const robot_model::RobotModelConstPtr &robot_model,
                 collision_detection::WorldPtr world = collision_detection::WorldPtr(new collision_detection::World()));
 
   /** \brief construct using a urdf and srdf.

--- a/planning_scene/src/planning_scene.cpp
+++ b/planning_scene/src/planning_scene.cpp
@@ -120,7 +120,7 @@ bool planning_scene::PlanningScene::isEmpty(const moveit_msgs::PlanningSceneWorl
   return msg.collision_objects.empty() && msg.octomap.octomap.data.empty();
 }
 
-planning_scene::PlanningScene::PlanningScene(const robot_model::RobotModelPtr &robot_model,
+planning_scene::PlanningScene::PlanningScene(const robot_model::RobotModelConstPtr &robot_model,
                                              collision_detection::WorldPtr world) :
   kmodel_(robot_model),
   world_(world),


### PR DESCRIPTION
Fixed constructor to more accurately represent the fact that the robot_model_ pointer is const throughout the class. 
You can see in the constructor function that this parameter is used for only assigning to a const ptr. 

This change is also needed for some speed up improvements im working on for PlanningSceneMonitor
