### PR TITLE
Constraint sampler inverse kinematics fix

### DIFF
--- a/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler.h
+++ b/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler.h
@@ -232,7 +232,7 @@ public:
    * @return True if a sample was successfully projected, false otherwise
    */
   virtual bool project(robot_state::RobotState &state,
-                       unsigned int max_attempts) = 0;
+                       unsigned int max_attempts, bool use_state_as_seed = true) = 0;
 
   /**
    * \brief Returns whether or not the constraint sampler is valid or not.

--- a/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
+++ b/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
@@ -122,7 +122,8 @@ public:
                       unsigned int max_attempts);
 
   virtual bool project(robot_state::RobotState &state,
-                       unsigned int max_attempts);
+                       unsigned int max_attempts,
+                       bool use_state_as_seed = true);
 
   /**
    * \brief Gets the number of constrained joints - joints that have an
@@ -453,7 +454,8 @@ public:
                       unsigned int max_attempts);
 
   virtual bool project(robot_state::RobotState &state,
-                       unsigned int max_attempts);
+                       unsigned int max_attempts,
+                       bool use_state_as_seed=true);
   /**
    * \brief Returns a pose that falls within the constraint regions.
    *
@@ -512,7 +514,7 @@ protected:
    */
   bool callIK(const geometry_msgs::Pose &ik_query, const kinematics::KinematicsBase::IKCallbackFn &adapted_ik_validity_callback,
               double timeout, robot_state::RobotState &state, bool use_as_seed);
-  bool sampleHelper(robot_state::RobotState &state, const robot_state::RobotState &reference_state, unsigned int max_attempts, bool project);
+  bool sampleHelper(robot_state::RobotState &state, const robot_state::RobotState &reference_state, unsigned int max_attempts, bool use_state_as_seed);
   bool validate(robot_state::RobotState &state) const;
 
   random_numbers::RandomNumberGenerator random_number_generator_; /**< \brief Random generator used by the sampler */

--- a/constraint_samplers/include/moveit/constraint_samplers/union_constraint_sampler.h
+++ b/constraint_samplers/include/moveit/constraint_samplers/union_constraint_sampler.h
@@ -152,7 +152,7 @@ public:
    */
   virtual bool sample(robot_state::RobotState &state, const robot_state::RobotState &reference_state, unsigned int max_attempts);
 
-  virtual bool project(robot_state::RobotState &state, unsigned int max_attempts);
+  virtual bool project(robot_state::RobotState &state, unsigned int max_attempts, bool use_state_as_seed = true);
 
   /**
    * \brief Get the name of the constraint sampler, for debugging purposes

--- a/constraint_samplers/src/default_constraint_samplers.cpp
+++ b/constraint_samplers/src/default_constraint_samplers.cpp
@@ -171,7 +171,8 @@ bool constraint_samplers::JointConstraintSampler::sample(robot_state::RobotState
 }
 
 bool constraint_samplers::JointConstraintSampler::project(robot_state::RobotState &state,
-                                                          unsigned int max_attempts)
+                                                          unsigned int max_attempts,
+                                                          bool use_state_as_seed)
 {
   return sample(state, state, max_attempts);
 }
@@ -489,7 +490,7 @@ bool constraint_samplers::IKConstraintSampler::sample(robot_state::RobotState &s
   return sampleHelper(state, reference_state, max_attempts, false);
 }
 
-bool constraint_samplers::IKConstraintSampler::sampleHelper(robot_state::RobotState &state, const robot_state::RobotState &reference_state, unsigned int max_attempts, bool project)
+bool constraint_samplers::IKConstraintSampler::sampleHelper(robot_state::RobotState &state, const robot_state::RobotState &reference_state, unsigned int max_attempts, bool use_state_as_seed)
 {
   if (!is_valid_)
   {
@@ -522,16 +523,17 @@ bool constraint_samplers::IKConstraintSampler::sampleHelper(robot_state::RobotSt
     ik_query.orientation.z = quat.z();
     ik_query.orientation.w = quat.w();
 
-    if (callIK(ik_query, adapted_ik_validity_callback, ik_timeout_, state, project && a == 0))
+    if (callIK(ik_query, adapted_ik_validity_callback, ik_timeout_, state, use_state_as_seed && a == 0))
       return true;
   }
   return false;
 }
 
 bool constraint_samplers::IKConstraintSampler::project(robot_state::RobotState &state,
-                                                       unsigned int max_attempts)
+                                                       unsigned int max_attempts,
+                                                       bool use_state_as_seed)
 {
-  return sampleHelper(state, state, max_attempts, true);
+  return sampleHelper(state, state, max_attempts, use_state_as_seed);
 }
 
 bool constraint_samplers::IKConstraintSampler::validate(robot_state::RobotState &state) const

--- a/constraint_samplers/src/union_constraint_sampler.cpp
+++ b/constraint_samplers/src/union_constraint_sampler.cpp
@@ -140,10 +140,10 @@ bool constraint_samplers::UnionConstraintSampler::sample(robot_state::RobotState
   return true;
 }
 
-bool constraint_samplers::UnionConstraintSampler::project(robot_state::RobotState &state, unsigned int max_attempts)
+bool constraint_samplers::UnionConstraintSampler::project(robot_state::RobotState &state, unsigned int max_attempts, bool use_state_as_seed)
 {
   for (std::size_t i = 0 ; i < samplers_.size() ; ++i)
-    if (!samplers_[i]->project(state, max_attempts))
+    if (!samplers_[i]->project(state, max_attempts, use_state_as_seed))
       return false;
   return true;
 }


### PR DESCRIPTION
I added an extra argument to ConstrainedSampler::project that specifies whether or not to use the passed in state as a seed, which defaults to true.

I added this argument to all of the derived classes too.

This will let ompl_interface classes that use the ConstrainedSamplers to force randomized seeds when it detects failures at sampling goals.

The problem it fixes is talked about here
https://github.com/ros-planning/moveit_planners/issues/44#issuecomment-50715025
