### PR TITLE
Getter for all tips (links) of every end effector in a joint model group

### DIFF
--- a/robot_model/include/moveit/robot_model/joint_model_group.h
+++ b/robot_model/include/moveit/robot_model/joint_model_group.h
@@ -467,7 +467,23 @@ public:
   {
     return attached_end_effector_names_;
   }
-  
+
+  /**
+   * \brief Get a vector of end effector tips included in a particular joint model group as defined by the SRDF end effector semantic
+   *        e.g. for a humanoid robot this would return 4 tips for the hands and feet
+   * \param tips - the output vector of link models of the tips
+   * \return true on success
+   */
+  bool getEndEffectorTips(std::vector<const LinkModel*> &tips);
+
+  /**
+   * \brief Get a vector of end effector tips included in a particular joint model group as defined by the SRDF end effector semantic
+   *        e.g. for a humanoid robot this would return 4 tips for the hands and feet
+   * \param tips - the output vector of link names of the tips
+   * \return true on success
+   */
+  bool getEndEffectorTips(std::vector<std::string> &tips);
+
   /** \brief Get the bounds for all the active joints */
   const JointBoundsVector& getActiveJointModelsBounds() const
   {

--- a/robot_model/src/joint_model_group.cpp
+++ b/robot_model/src/joint_model_group.cpp
@@ -474,6 +474,46 @@ void moveit::core::JointModelGroup::attachEndEffector(const std::string &eef_nam
   attached_end_effector_names_.push_back(eef_name);
 }
 
+bool moveit::core::JointModelGroup::getEndEffectorTips(std::vector<std::string> &tips)
+{
+  // Get a vector of tip links
+  std::vector<const LinkModel*> tip_links;
+  if (!getEndEffectorTips(tip_links))
+    return false;
+
+  // Convert to string names
+  tips.clear();
+  for (std::size_t i = 0; i < tip_links.size(); ++i)
+  {
+    tips.push_back(tip_links[i]->getName());
+  }
+  return true;
+}
+
+bool moveit::core::JointModelGroup::getEndEffectorTips(std::vector<const LinkModel*> &tips)
+{
+  for (std::size_t i = 0; i < getAttachedEndEffectorNames().size(); ++i)
+  {
+    const JointModelGroup *eef = parent_model_->getEndEffector(getAttachedEndEffectorNames()[i]);
+    if (!eef)
+    {
+      logError("Unable to find joint model group for eef");
+      return false;
+    }
+    const std::string &eef_parent = eef->getEndEffectorParentGroup().second;
+
+    const LinkModel* eef_link = parent_model_->getLinkModel(eef_parent);
+    if (!eef_link)
+    {
+      logError("Unable to find end effector link for eef");
+      return false;
+    }
+
+    tips.push_back(eef_link);
+  }
+  return true;
+}
+
 int moveit::core::JointModelGroup::getVariableGroupIndex(const std::string &variable) const
 {
   VariableIndexMap::const_iterator it = joint_variables_index_map_.find(variable);


### PR DESCRIPTION
Each semantic end effector defined in the SRDF has a parent link that attaches it to the kinematics of the robot. This function will give you all the parent links, or tips as they are sometimes referred to in code. It returns them as LinkModels or strings. This is useful for multi-tip robots like humanoids.
