### PR TITLE
Moved find_package angles to within CATKIN_ENABLE_TESTING

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,6 @@ COMPONENTS
 
 find_package(Eigen REQUIRED)
 find_package(octomap REQUIRED)
-find_package(angles)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(LIBFCL REQUIRED fcl)

--- a/constraint_samplers/CMakeLists.txt
+++ b/constraint_samplers/CMakeLists.txt
@@ -26,6 +26,8 @@ if(CATKIN_ENABLE_TESTING)
   find_package(orocos_kdl)
   find_package(angles)
 
+  include_directories(${angles_INCLUDE_DIRS})
+
   catkin_add_gtest(test_constraint_samplers
     test/test_constraint_samplers.cpp
     test/pr2_arm_kinematics_plugin.cpp
@@ -35,5 +37,6 @@ if(CATKIN_ENABLE_TESTING)
     ${MOVEIT_LIB_NAME}
     ${catkin_LIBRARIES}
     ${orocos_kdl_LIBRARIES}
+    ${angles_LIBRARIES}
   )
 endif()

--- a/constraint_samplers/CMakeLists.txt
+++ b/constraint_samplers/CMakeLists.txt
@@ -24,6 +24,7 @@ install(DIRECTORY include/
 
 if(CATKIN_ENABLE_TESTING)
   find_package(orocos_kdl)
+  find_package(angles)
 
   catkin_add_gtest(test_constraint_samplers
     test/test_constraint_samplers.cpp


### PR DESCRIPTION
Fix for https://github.com/ros-planning/moveit_core/issues/181 on top of previous fix https://github.com/ros-planning/moveit_core/pull/190

Moved find_package of angles to sub-folder that uses it for constraint_samplers testing, inside of CATKIN_ENABLE_TESTING
