### PR TITLE
Fixed missing test depends for tf_conversions

### DIFF
--- a/constraint_samplers/CMakeLists.txt
+++ b/constraint_samplers/CMakeLists.txt
@@ -25,8 +25,9 @@ install(DIRECTORY include/
 if(CATKIN_ENABLE_TESTING)
   find_package(orocos_kdl)
   find_package(angles)
+  find_package(tf_conversions)
 
-  include_directories(${angles_INCLUDE_DIRS})
+  include_directories(${angles_INCLUDE_DIRS} ${tf_conversions_INCLUDE_DIRS})
 
   catkin_add_gtest(test_constraint_samplers
     test/test_constraint_samplers.cpp
@@ -38,5 +39,6 @@ if(CATKIN_ENABLE_TESTING)
     ${catkin_LIBRARIES}
     ${orocos_kdl_LIBRARIES}
     ${angles_LIBRARIES}
+    ${tf_conversions_LIBRARIES}
   )
 endif()

--- a/package.xml
+++ b/package.xml
@@ -49,6 +49,7 @@
   <build_depend>rostime</build_depend>
   <build_depend>cmake_modules</build_depend>
   <test_depend>angles</test_depend>
+  <test_depend>tf_conversions</test_depend>
 
   <run_depend>console_bridge</run_depend>
   <run_depend>random_numbers</run_depend>


### PR DESCRIPTION
Jenkins is reporting:

```
See <http://jenkins.ros.org/job/devel-hydro-moveit_core/ARCH_PARAM=amd64,UBUNTU_PARAM=precise,label=devel/26/changes>

Changes:

[davetcoleman] Added new setToRandomPositions function that allows custom random number generator to be specified

------------------------------------------
[...truncated 1202 lines...]
Scanning dependencies of target sensor_msgs_generate_messages_lisp
[  8%] Built target sensor_msgs_generate_messages_lisp
Scanning dependencies of target shape_msgs_generate_messages_cpp
[  8%] Built target shape_msgs_generate_messages_cpp
Scanning dependencies of target octomap_msgs_generate_messages_cpp
[  8%] Built target octomap_msgs_generate_messages_cpp
Scanning dependencies of target octomap_msgs_generate_messages_py
[  8%] Built target octomap_msgs_generate_messages_py
Scanning dependencies of target geometry_msgs_generate_messages_lisp
[  8%] Built target geometry_msgs_generate_messages_lisp
Scanning dependencies of target actionlib_msgs_generate_messages_cpp
[  8%] Built target actionlib_msgs_generate_messages_cpp
Scanning dependencies of target trajectory_msgs_generate_messages_cpp
[  8%] Built target trajectory_msgs_generate_messages_cpp
Scanning dependencies of target geometry_msgs_generate_messages_py
[  8%] Built target geometry_msgs_generate_messages_py
Scanning dependencies of target geometry_msgs_generate_messages_cpp
[  8%] Built target geometry_msgs_generate_messages_cpp
Scanning dependencies of target roscpp_generate_messages_cpp
[  8%] Built target roscpp_generate_messages_cpp
Scanning dependencies of target roscpp_generate_messages_py
[  8%] Built target roscpp_generate_messages_py
Scanning dependencies of target rosgraph_msgs_generate_messages_lisp
[  8%] Built target rosgraph_msgs_generate_messages_lisp
Scanning dependencies of target rosgraph_msgs_generate_messages_py
[  8%] Built target rosgraph_msgs_generate_messages_py
Scanning dependencies of target moveit_kinematics_base
[ 10%] Building CXX object moveit_core/kinematics_base/CMakeFiles/moveit_kinematics_base.dir/src/kinematics_base.cpp.o
Linking CXX shared library ../../devel/lib/libmoveit_kinematics_base.so
[ 10%] Built target moveit_kinematics_base
Scanning dependencies of target moveit_robot_model
[ 12%] Building CXX object moveit_core/robot_model/CMakeFiles/moveit_robot_model.dir/src/link_model.cpp.o
[ 14%] Building CXX object moveit_core/robot_model/CMakeFiles/moveit_robot_model.dir/src/joint_model.cpp.o
[ 16%] Building CXX object moveit_core/robot_model/CMakeFiles/moveit_robot_model.dir/src/fixed_joint_model.cpp.o
[ 18%] Building CXX object moveit_core/robot_model/CMakeFiles/moveit_robot_model.dir/src/revolute_joint_model.cpp.o
[ 20%] Building CXX object moveit_core/robot_model/CMakeFiles/moveit_robot_model.dir/src/prismatic_joint_model.cpp.o
[ 22%] Building CXX object moveit_core/robot_model/CMakeFiles/moveit_robot_model.dir/src/planar_joint_model.cpp.o
[ 24%] Building CXX object moveit_core/robot_model/CMakeFiles/moveit_robot_model.dir/src/floating_joint_model.cpp.o
[ 26%] Building CXX object moveit_core/robot_model/CMakeFiles/moveit_robot_model.dir/src/joint_model_group.cpp.o
[ 28%] Building CXX object moveit_core/robot_model/CMakeFiles/moveit_robot_model.dir/src/robot_model.cpp.o
Linking CXX shared library ../../devel/lib/libmoveit_robot_model.so
[ 28%] Built target moveit_robot_model
Scanning dependencies of target moveit_transforms
[ 30%] Building CXX object moveit_core/transforms/CMakeFiles/moveit_transforms.dir/src/transforms.cpp.o
Linking CXX shared library ../../devel/lib/libmoveit_transforms.so
[ 30%] Built target moveit_transforms
Scanning dependencies of target moveit_robot_state
[ 32%] Building CXX object moveit_core/robot_state/CMakeFiles/moveit_robot_state.dir/src/robot_state.cpp.o
[ 34%] Building CXX object moveit_core/robot_state/CMakeFiles/moveit_robot_state.dir/src/attached_body.cpp.o
[ 36%] Building CXX object moveit_core/robot_state/CMakeFiles/moveit_robot_state.dir/src/conversions.cpp.o
Linking CXX shared library ../../devel/lib/libmoveit_robot_state.so
[ 36%] Built target moveit_robot_state
Scanning dependencies of target moveit_robot_trajectory
[ 38%] Building CXX object moveit_core/robot_trajectory/CMakeFiles/moveit_robot_trajectory.dir/src/robot_trajectory.cpp.o
Linking CXX shared library ../../devel/lib/libmoveit_robot_trajectory.so
[ 38%] Built target moveit_robot_trajectory
Scanning dependencies of target moveit_collision_detection
[ 40%] Building CXX object moveit_core/collision_detection/CMakeFiles/moveit_collision_detection.dir/src/world.cpp.o
[ 42%] Building CXX object moveit_core/collision_detection/CMakeFiles/moveit_collision_detection.dir/src/world_diff.cpp.o
[ 44%] Building CXX object moveit_core/collision_detection/CMakeFiles/moveit_collision_detection.dir/src/collision_world.cpp.o
[ 46%] Building CXX object moveit_core/collision_detection/CMakeFiles/moveit_collision_detection.dir/src/collision_robot.cpp.o
[ 48%] Building CXX object moveit_core/collision_detection/CMakeFiles/moveit_collision_detection.dir/src/collision_matrix.cpp.o
[ 51%] Building CXX object moveit_core/collision_detection/CMakeFiles/moveit_collision_detection.dir/src/collision_tools.cpp.o
[ 53%] Building CXX object moveit_core/collision_detection/CMakeFiles/moveit_collision_detection.dir/src/collision_octomap_filter.cpp.o
[ 55%] Building CXX object moveit_core/collision_detection/CMakeFiles/moveit_collision_detection.dir/src/allvalid/collision_robot_allvalid.cpp.o
[ 57%] Building CXX object moveit_core/collision_detection/CMakeFiles/moveit_collision_detection.dir/src/allvalid/collision_world_allvalid.cpp.o
Linking CXX shared library ../../devel/lib/libmoveit_collision_detection.so
[ 57%] Built target moveit_collision_detection
Scanning dependencies of target moveit_collision_detection_fcl
[ 59%] Building CXX object moveit_core/collision_detection_fcl/CMakeFiles/moveit_collision_detection_fcl.dir/src/collision_common.cpp.o
[ 61%] Building CXX object moveit_core/collision_detection_fcl/CMakeFiles/moveit_collision_detection_fcl.dir/src/collision_robot_fcl.cpp.o
[ 63%] Building CXX object moveit_core/collision_detection_fcl/CMakeFiles/moveit_collision_detection_fcl.dir/src/collision_world_fcl.cpp.o
Linking CXX shared library ../../devel/lib/libmoveit_collision_detection_fcl.so
[ 63%] Built target moveit_collision_detection_fcl
Scanning dependencies of target moveit_kinematic_constraints
[ 65%] Building CXX object moveit_core/kinematic_constraints/CMakeFiles/moveit_kinematic_constraints.dir/src/kinematic_constraint.cpp.o
[ 67%] Building CXX object moveit_core/kinematic_constraints/CMakeFiles/moveit_kinematic_constraints.dir/src/utils.cpp.o
Linking CXX shared library ../../devel/lib/libmoveit_kinematic_constraints.so
[ 67%] Built target moveit_kinematic_constraints
Scanning dependencies of target moveit_trajectory_processing
[ 69%] Building CXX object moveit_core/trajectory_processing/CMakeFiles/moveit_trajectory_processing.dir/src/iterative_time_parameterization.cpp.o
[ 71%] Building CXX object moveit_core/trajectory_processing/CMakeFiles/moveit_trajectory_processing.dir/src/trajectory_tools.cpp.o
Linking CXX shared library ../../devel/lib/libmoveit_trajectory_processing.so
[ 71%] Built target moveit_trajectory_processing
Scanning dependencies of target moveit_planning_scene
[ 73%] Building CXX object moveit_core/planning_scene/CMakeFiles/moveit_planning_scene.dir/src/planning_scene.cpp.o
Linking CXX shared library ../../devel/lib/libmoveit_planning_scene.so
[ 73%] Built target moveit_planning_scene
Scanning dependencies of target moveit_constraint_samplers
[ 75%] Building CXX object moveit_core/constraint_samplers/CMakeFiles/moveit_constraint_samplers.dir/src/constraint_sampler.cpp.o
[ 77%] Building CXX object moveit_core/constraint_samplers/CMakeFiles/moveit_constraint_samplers.dir/src/default_constraint_samplers.cpp.o
[ 79%] Building CXX object moveit_core/constraint_samplers/CMakeFiles/moveit_constraint_samplers.dir/src/union_constraint_sampler.cpp.o
[ 81%] Building CXX object moveit_core/constraint_samplers/CMakeFiles/moveit_constraint_samplers.dir/src/constraint_sampler_manager.cpp.o
[ 83%] Building CXX object moveit_core/constraint_samplers/CMakeFiles/moveit_constraint_samplers.dir/src/constraint_sampler_tools.cpp.o
Linking CXX shared library ../../devel/lib/libmoveit_constraint_samplers.so
[ 83%] Built target moveit_constraint_samplers
Scanning dependencies of target moveit_planning_interface
[ 85%] Building CXX object moveit_core/planning_interface/CMakeFiles/moveit_planning_interface.dir/src/planning_response.cpp.o
[ 87%] Building CXX object moveit_core/planning_interface/CMakeFiles/moveit_planning_interface.dir/src/planning_interface.cpp.o
Linking CXX shared library ../../devel/lib/libmoveit_planning_interface.so
[ 87%] Built target moveit_planning_interface
Scanning dependencies of target moveit_planning_request_adapter
[ 89%] Building CXX object moveit_core/planning_request_adapter/CMakeFiles/moveit_planning_request_adapter.dir/src/planning_request_adapter.cpp.o
Linking CXX shared library ../../devel/lib/libmoveit_planning_request_adapter.so
[ 89%] Built target moveit_planning_request_adapter
Scanning dependencies of target moveit_distance_field
[ 91%] Building CXX object moveit_core/distance_field/CMakeFiles/moveit_distance_field.dir/src/distance_field.cpp.o
[ 93%] Building CXX object moveit_core/distance_field/CMakeFiles/moveit_distance_field.dir/src/propagation_distance_field.cpp.o
[ 95%] Building CXX object moveit_core/distance_field/CMakeFiles/moveit_distance_field.dir/src/find_internal_points.cpp.o
Linking CXX shared library ../../devel/lib/libmoveit_distance_field.so
[ 95%] Built target moveit_distance_field
Scanning dependencies of target moveit_kinematics_metrics
[ 97%] Building CXX object moveit_core/kinematics_metrics/CMakeFiles/moveit_kinematics_metrics.dir/src/kinematics_metrics.cpp.o
Linking CXX shared library ../../devel/lib/libmoveit_kinematics_metrics.so
[ 97%] Built target moveit_kinematics_metrics
Scanning dependencies of target moveit_dynamics_solver
[100%] Building CXX object moveit_core/dynamics_solver/CMakeFiles/moveit_dynamics_solver.dir/src/dynamics_solver.cpp.o
Linking CXX shared library ../../devel/lib/libmoveit_dynamics_solver.so
[100%] Built target moveit_dynamics_solver
Executing command 'make tests'
[  0%] Built target visualization_msgs_generate_messages_py
[  0%] Built target visualization_msgs_generate_messages_cpp
[  0%] Built target roscpp_generate_messages_lisp
[  0%] Built target moveit_msgs_generate_messages_cpp
[  0%] Built target moveit_msgs_generate_messages_lisp
[  0%] Built target sensor_msgs_generate_messages_cpp
[  0%] Built target moveit_msgs_generate_messages_py
[  0%] Built target actionlib_msgs_generate_messages_py
[  0%] Built target trajectory_msgs_generate_messages_py
[  0%] Built target std_msgs_generate_messages_lisp
[  0%] Built target std_msgs_generate_messages_cpp
[  0%] Built target std_msgs_generate_messages_py
[  0%] Built target rosgraph_msgs_generate_messages_cpp
[  0%] Built target actionlib_msgs_generate_messages_lisp
[  0%] Built target visualization_msgs_generate_messages_lisp
[  0%] Built target shape_msgs_generate_messages_lisp
[  0%] Built target object_recognition_msgs_generate_messages_lisp
[  0%] Built target object_recognition_msgs_generate_messages_py
[  0%] Built target object_recognition_msgs_generate_messages_cpp
[  0%] Built target sensor_msgs_generate_messages_py
[  0%] Built target shape_msgs_generate_messages_py
[  0%] Built target octomap_msgs_generate_messages_lisp
[  0%] Built target trajectory_msgs_generate_messages_lisp
[  0%] Built target sensor_msgs_generate_messages_lisp
[  0%] Built target shape_msgs_generate_messages_cpp
[  0%] Built target octomap_msgs_generate_messages_cpp
[  0%] Built target octomap_msgs_generate_messages_py
[  0%] Built target geometry_msgs_generate_messages_lisp
[  0%] Built target actionlib_msgs_generate_messages_cpp
[  0%] Built target trajectory_msgs_generate_messages_cpp
[  0%] Built target geometry_msgs_generate_messages_py
[  0%] Built target geometry_msgs_generate_messages_cpp
[  0%] Built target roscpp_generate_messages_cpp
[  0%] Built target roscpp_generate_messages_py
[  0%] Built target rosgraph_msgs_generate_messages_lisp
[  0%] Built target rosgraph_msgs_generate_messages_py
[  5%] Built target moveit_distance_field
Scanning dependencies of target gtest
[  6%] Building CXX object gtest/CMakeFiles/gtest.dir/src/gtest-all.cc.o
Linking CXX shared library libgtest.so
[  6%] Built target gtest
Scanning dependencies of target gtest_main
[  8%] Building CXX object gtest/CMakeFiles/gtest_main.dir/src/gtest_main.cc.o
Linking CXX shared library libgtest_main.so
[  8%] Built target gtest_main
Scanning dependencies of target test_distance_field
[ 10%] Building CXX object moveit_core/distance_field/CMakeFiles/test_distance_field.dir/test/test_distance_field.cpp.o
Linking CXX executable ../../devel/lib/moveit_core/test_distance_field
[ 10%] Built target test_distance_field
[ 12%] Built target moveit_kinematics_base
[ 13%] Built target moveit_profiler
[ 15%] Built target moveit_exceptions
[ 31%] Built target moveit_robot_model
Scanning dependencies of target test_robot_model
[ 32%] Building CXX object moveit_core/robot_model/CMakeFiles/test_robot_model.dir/test/test.cpp.o
Linking CXX executable ../../devel/lib/moveit_core/test_robot_model
[ 32%] Built target test_robot_model
[ 34%] Built target moveit_transforms
Scanning dependencies of target test_transforms
[ 36%] Building CXX object moveit_core/transforms/CMakeFiles/test_transforms.dir/test/test_transforms.cpp.o
Linking CXX executable ../../devel/lib/moveit_core/test_transforms
[ 36%] Built target test_transforms
[ 41%] Built target moveit_robot_state
Scanning dependencies of target test_robot_state_complex
[ 43%] Building CXX object moveit_core/robot_state/CMakeFiles/test_robot_state_complex.dir/test/test_kinematic_complex.cpp.o
Linking CXX executable ../../devel/lib/moveit_core/test_robot_state_complex
[ 43%] Built target test_robot_state_complex
Scanning dependencies of target test_robot_state
[ 44%] Building CXX object moveit_core/robot_state/CMakeFiles/test_robot_state.dir/test/test_kinematic.cpp.o
Linking CXX executable ../../devel/lib/moveit_core/test_robot_state
[ 44%] Built target test_robot_state
[ 60%] Built target moveit_collision_detection
Scanning dependencies of target test_world
[ 62%] Building CXX object moveit_core/collision_detection/CMakeFiles/test_world.dir/test/test_world.cpp.o
Linking CXX executable ../../devel/lib/moveit_core/test_world
[ 62%] Built target test_world
Scanning dependencies of target test_world_diff
[ 63%] Building CXX object moveit_core/collision_detection/CMakeFiles/test_world_diff.dir/test/test_world_diff.cpp.o
Linking CXX executable ../../devel/lib/moveit_core/test_world_diff
[ 63%] Built target test_world_diff
[ 68%] Built target moveit_collision_detection_fcl
Scanning dependencies of target test_fcl_collision_detection
[ 70%] Building CXX object moveit_core/collision_detection_fcl/CMakeFiles/test_fcl_collision_detection.dir/test/test_fcl_collision_detection.cpp.o
Linking CXX executable ../../devel/lib/moveit_core/test_fcl_collision_detection
[ 70%] Built target test_fcl_collision_detection
[ 74%] Built target moveit_kinematic_constraints
Scanning dependencies of target test_constraints
[ 75%] Building CXX object moveit_core/kinematic_constraints/CMakeFiles/test_constraints.dir/test/test_constraints.cpp.o
Linking CXX executable ../../devel/lib/moveit_core/test_constraints
[ 75%] Built target test_constraints
[ 77%] Built target moveit_robot_trajectory
[ 81%] Built target moveit_trajectory_processing
[ 82%] Built target moveit_planning_scene
Scanning dependencies of target test_planning_scene
[ 84%] Building CXX object moveit_core/planning_scene/CMakeFiles/test_planning_scene.dir/test/test_planning_scene.cpp.o
Linking CXX executable ../../devel/lib/moveit_core/test_planning_scene
[ 84%] Built target test_planning_scene
[ 93%] Built target moveit_constraint_samplers
Scanning dependencies of target test_constraint_samplers
[ 94%] Building CXX object moveit_core/constraint_samplers/CMakeFiles/test_constraint_samplers.dir/test/test_constraint_samplers.cpp.o
In file included from /tmp/test_repositories/src_repository/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp:56:0:
/tmp/test_repositories/src_repository/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.h:46:35: fatal error: tf_conversions/tf_kdl.h: No such file or directory
compilation terminated.
make[3]: *** [moveit_core/constraint_samplers/CMakeFiles/test_constraint_samplers.dir/test/test_constraint_samplers.cpp.o] Error 1
make[2]: *** [moveit_core/constraint_samplers/CMakeFiles/test_constraint_samplers.dir/all] Error 2
make[1]: *** [CMakeFiles/tests.dir/rule] Error 2
make: *** [tests] Error 2
/!\  Failed to execute command '['make', 'tests']' with return code 2
Failed to execute command '['make', 'tests']' with return code 2
+ echo ============================================================
============================================================
+ echo '==== End' devel 'script.    Ignore the output below ====='
==== End devel script.    Ignore the output below =====
+ echo ============================================================
============================================================
I: Copying back the cached apt archive contents
I: new cache content ros-hydro-moveit-resources_0.5.0-0precise-20140617-0317-+0000_amd64.deb added
I: unmounting /var/cache/pbuilder/ccache filesystem
I: unmounting <http://jenkins.ros.org/job/devel-hydro-moveit_core/ARCH_PARAM=amd64,UBUNTU_PARAM=precise,label=devel/ws/> filesystem
I: unmounting /home/rosbuild filesystem
I: unmounting dev/pts filesystem
I: unmounting proc filesystem
I: cleaning the build env
I: removing directory /var/cache/pbuilder/build//12806 and its subdirectories
+ /bin/echo '^^^^^^^^^^^^^^^^^^  dispatch.sh ^^^^^^^^^^^^^^^^^^^^'
^^^^^^^^^^^^^^^^^^  dispatch.sh ^^^^^^^^^^^^^^^^^^^^
Recording test results
No test report files were found. Configuration error?
Build step 'Publish JUnit test result report' changed build result to FAILURE
```

Namely

> /tmp/test_repositories/src_repository/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.h:46:35: fatal error: tf_conversions/tf_kdl.h: No such file or directory
