### PR TITLE
Removed problematic assertion from default_constraint_samplers.cpp

### DIFF
--- a/constraint_samplers/src/default_constraint_samplers.cpp
+++ b/constraint_samplers/src/default_constraint_samplers.cpp
@@ -571,9 +571,7 @@ bool constraint_samplers::IKConstraintSampler::callIK(const geometry_msgs::Pose 
       solution[ik_joint_bijection[i]] = ik_sol[i];
     state.setJointGroupPositions(jmg_, solution);
 
-    assert(validate(state));
-
-    return true;
+    return validate(state);
   }
   else
   {


### PR DESCRIPTION
When doing a task where moveit is planning repeatedly, this assertion consistently fails for me after a few minutes of running.

Looking at the code, I see that the function it is in, callIK(), already returns a bool indicating success or failure, and callIK() is called from a sampling loop that keeps trying until success.  Therefore I don't see a problem with changing the "assert" to "return".
