### PR TITLE
fix test: isEmpty() requires that robot_state be diff

### DIFF
--- a/planning_scene/test/test_planning_scene.cpp
+++ b/planning_scene/test/test_planning_scene.cpp
@@ -90,6 +90,7 @@ TEST(PlanningScene, LoadRestoreDiff)
   world.addToObject("sphere", shapes::ShapeConstPtr(new shapes::Sphere(0.4)), id);
 
   moveit_msgs::PlanningScene ps_msg;
+  ps_msg.robot_state.is_diff = true;
   EXPECT_TRUE(planning_scene::PlanningScene::isEmpty(ps_msg));
   ps->getPlanningSceneMsg(ps_msg);
   ps->setPlanningSceneMsg(ps_msg);


### PR DESCRIPTION
Fixes #116. This was probably broken by https://github.com/ros-planning/moveit_core/commit/103a268a819f7f9e2c3adb929f5948ab62e44f7f in which isEmpty(RobotState) began to require is_diff to be true -- of course, the default value is false.

@isucan -- I chose to fix the test here -- but perhaps the definition of isEmpty() is logically wrong instead?
