### PR TITLE
Fix truncated debug message

### DIFF
--- a/robot_model/src/robot_model.cpp
+++ b/robot_model/src/robot_model.cpp
@@ -113,9 +113,9 @@ void moveit::core::RobotModel::buildModel(const urdf::ModelInterface &urdf_model
     logDebug("... constructing joint group states"); 
     buildGroupStates(srdf_model);
 
-    std::stringstream ss;
-    printModelInfo(ss);
-    logDebug("%s", ss.str().c_str());
+    // For debugging entire model
+    if (false)
+      printModelInfo(std::cout);
   }
   else
     logWarn("No root link found");


### PR DESCRIPTION
There is a bug that does not allow an entire robot model to be printed to debug logging because of a 1024 byte limit on the message:

https://github.com/ros/console_bridge/blob/master/src/console.cpp#L75

Instead you only get a truncated version of the model info. As a workaround I thought we could possibly use std::cout and surround it with NDEBUG as discussed in https://github.com/ros-infrastructure/bloom/issues/327#issuecomment-64295814

My fix here probably isn't right though, I welcome corrections and feedback. Thanks!
