### PR TITLE
fix spelling error in guard

### DIFF
--- a/backtrace/include/moveit/backtrace/backtrace.h
+++ b/backtrace/include/moveit/backtrace/backtrace.h
@@ -33,7 +33,7 @@
  *********************************************************************/
 
 #ifndef MOVEIT_BACKTRACE_
-#define MOVEIT_BACKTARCE_
+#define MOVEIT_BACKTRACE_
 
 #include <iostream>
 


### PR DESCRIPTION
Trivial to fix to include guard. (yay clang!)
