### PR TITLE
Allow KinematicBase to have RobotModel passed in to save loading time

### DIFF
--- a/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -336,7 +336,7 @@ public:
                           const moveit::core::RobotModel* robot_model)
   {
     // For IK solvers that do not support passing in a robot_model pointer
-    return initialize(robot_description, group_name, base_frame, tip_frame, search_discretization, NULL);
+    return initialize(robot_description, group_name, base_frame, tip_frame, search_discretization);
   }
 
   /**

--- a/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -308,36 +308,14 @@ public:
    * @param tip_frame The tip of the chain
    * @param search_discretization The discretization of the search when the solver steps through the redundancy
    * @return True if initialization was successful, false otherwise
+   *
+   * Note: this is intended to be removed in future ROS versions in favor of robot_model being passed in
    */
-  MOVEIT_DEPRECATED
   virtual bool initialize(const std::string& robot_description,
                           const std::string& group_name,
                           const std::string& base_frame,
                           const std::string& tip_frame,
                           double search_discretization) = 0;
-
-  /**
-   * @brief  Initialization function for the kinematics, for use with kinematic chain IK solvers
-   * @param robot_description This parameter can be used as an identifier for the robot kinematics it is computed for;
-   * For example, the name of the ROS parameter that contains the robot description;
-   * @param group_name The group for which this solver is being configured
-   * @param base_frame The base frame in which all input poses are expected.
-   * This may (or may not) be the root frame of the chain that the solver operates on
-   * @param tip_frame The tip of the chain
-   * @param search_discretization The discretization of the search when the solver steps through the redundancy
-   * @param robot_model - intended to replace reliance on robot_description, this allows the URDF to be loaded much quicker
-   * @return True if initialization was successful, false otherwise
-   */
-  virtual bool initialize(const std::string& robot_description,
-                          const std::string& group_name,
-                          const std::string& base_frame,
-                          const std::string& tip_frame,
-                          double search_discretization,
-                          const moveit::core::RobotModel* robot_model)
-  {
-    // For IK solvers that do not support passing in a robot_model pointer
-    return initialize(robot_description, group_name, base_frame, tip_frame, search_discretization);
-  }
 
   /**
    * @brief  Initialization function for the kinematics, for use with non-chain IK solvers
@@ -348,28 +326,49 @@ public:
    * This may (or may not) be the root frame of the chain that the solver operates on
    * @param tip_frames A vector of tips of the kinematic tree
    * @param search_discretization The discretization of the search when the solver steps through the redundancy
-   * @param robot_model - intended to replace reliance on robot_description, this allows the URDF to be loaded much quicker
    * @return True if initialization was successful, false otherwise
+   *
+   * Note: this is intended to be removed in future ROS versions in favor of robot_model being passed in
    */
   virtual bool initialize(const std::string& robot_description,
                           const std::string& group_name,
                           const std::string& base_frame,
                           const std::vector<std::string>& tip_frames,
-                          double search_discretization,
-                          const moveit::core::RobotModel* robot_model)
+                          double search_discretization)
   {
     // For IK solvers that do not support multiple tip frames, fall back to single pose call
     if (tip_frames.size() == 1)
     {
       return initialize(robot_description,
-        group_name,
-        base_frame,
-        tip_frames[0],
-        search_discretization,
-        robot_model);
+                        group_name,
+                        base_frame,
+                        tip_frames[0],
+                        search_discretization);
     }
 
     logError("moveit.kinematics_base: This kinematic solver does not support initialization with more than one tip frames");
+    return false;
+  }
+
+  /**
+   * @brief  Initialization function for the kinematics, for use with kinematic chain IK solvers
+   * @param robot_model - allow the URDF to be loaded much quicker by passing in a pre-parsed model of the robot
+   * @param group_name The group for which this solver is being configured
+   * @param base_frame The base frame in which all input poses are expected.
+   * This may (or may not) be the root frame of the chain that the solver operates on
+   * @param tip_frame The tip of the chain
+   * @param search_discretization The discretization of the search when the solver steps through the redundancy
+   * @return True if initialization was successful, false otherwise
+   */
+  virtual bool initialize(const moveit::core::RobotModel* robot_model,
+                          const std::string& group_name,
+                          const std::string& base_frame,
+                          const std::vector<std::string>& tip_frames,
+                          double search_discretization)
+                          
+  {
+    // For IK solvers that do not support passing in a robot_model pointer, return false and have
+    // the kinematics_plugin_loader try the older version of loading
     return false;
   }
 

--- a/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -42,6 +42,7 @@
 #include <boost/function.hpp>
 #include <console_bridge/console.h>
 #include <string>
+#include <moveit/macros/deprecation.h>
 
 namespace moveit
 {
@@ -49,8 +50,10 @@ namespace core
 {
 class JointModelGroup;
 class RobotState;
+class RobotModel;
 }
 }
+
 
 /** @brief API for forward and inverse kinematics */
 namespace kinematics
@@ -306,11 +309,35 @@ public:
    * @param search_discretization The discretization of the search when the solver steps through the redundancy
    * @return True if initialization was successful, false otherwise
    */
+  MOVEIT_DEPRECATED
   virtual bool initialize(const std::string& robot_description,
                           const std::string& group_name,
                           const std::string& base_frame,
                           const std::string& tip_frame,
                           double search_discretization) = 0;
+
+  /**
+   * @brief  Initialization function for the kinematics, for use with kinematic chain IK solvers
+   * @param robot_description This parameter can be used as an identifier for the robot kinematics it is computed for;
+   * For example, the name of the ROS parameter that contains the robot description;
+   * @param group_name The group for which this solver is being configured
+   * @param base_frame The base frame in which all input poses are expected.
+   * This may (or may not) be the root frame of the chain that the solver operates on
+   * @param tip_frame The tip of the chain
+   * @param search_discretization The discretization of the search when the solver steps through the redundancy
+   * @param robot_model - intended to replace reliance on robot_description, this allows the URDF to be loaded much quicker
+   * @return True if initialization was successful, false otherwise
+   */
+  virtual bool initialize(const std::string& robot_description,
+                          const std::string& group_name,
+                          const std::string& base_frame,
+                          const std::string& tip_frame,
+                          double search_discretization,
+                          const moveit::core::RobotModel* robot_model)
+  {
+    // For IK solvers that do not support passing in a robot_model pointer
+    return initialize(robot_description, group_name, base_frame, tip_frame, search_discretization, NULL);
+  }
 
   /**
    * @brief  Initialization function for the kinematics, for use with non-chain IK solvers
@@ -321,13 +348,15 @@ public:
    * This may (or may not) be the root frame of the chain that the solver operates on
    * @param tip_frames A vector of tips of the kinematic tree
    * @param search_discretization The discretization of the search when the solver steps through the redundancy
+   * @param robot_model - intended to replace reliance on robot_description, this allows the URDF to be loaded much quicker
    * @return True if initialization was successful, false otherwise
    */
   virtual bool initialize(const std::string& robot_description,
                           const std::string& group_name,
                           const std::string& base_frame,
                           const std::vector<std::string>& tip_frames,
-                          double search_discretization)
+                          double search_discretization,
+                          const moveit::core::RobotModel* robot_model)
   {
     // For IK solvers that do not support multiple tip frames, fall back to single pose call
     if (tip_frames.size() == 1)
@@ -336,7 +365,8 @@ public:
         group_name,
         base_frame,
         tip_frames[0],
-        search_discretization);
+        search_discretization,
+        robot_model);
     }
 
     logError("moveit.kinematics_base: This kinematic solver does not support initialization with more than one tip frames");

--- a/robot_model/include/moveit/robot_model/joint_model_group.h
+++ b/robot_model/include/moveit/robot_model/joint_model_group.h
@@ -125,6 +125,12 @@ public:
     return *parent_model_;
   }
 
+  /** \brief Get the pointer to the kinematic model this group is part of */
+  const RobotModel* getParentModelPtr() const
+  {
+    return parent_model_;
+  }
+
   /** \brief Get the name of the joint group */
   const std::string& getName() const
   {

--- a/robot_model/include/moveit/robot_model/robot_model.h
+++ b/robot_model/include/moveit/robot_model/robot_model.h
@@ -52,6 +52,9 @@
 #include <moveit/robot_model/revolute_joint_model.h>
 #include <moveit/robot_model/prismatic_joint_model.h>
 
+// Boost
+#include <boost/enable_shared_from_this.hpp>
+
 #include <Eigen/Geometry>
 #include <iostream>
 
@@ -64,7 +67,7 @@ namespace core
 
 /** \brief Definition of a kinematic model. This class is not thread
     safe, however multiple instances can be created */
-class RobotModel
+class RobotModel : public boost::enable_shared_from_this<RobotModel>
 {
 public:
   
@@ -74,6 +77,15 @@ public:
   
   /** \brief Destructor. Clear all memory. */
   ~RobotModel();
+
+  /**
+   * \brief Getter for the shared_ptr of this object. Note: this is not available until after the constructor is finished
+   * \return shared pointer
+   */
+  const boost::shared_ptr<const RobotModel> getConstPtr() const
+  {
+    return shared_from_this();
+  }
   
   /** \brief Get the model name. */
   const std::string& getName() const


### PR DESCRIPTION
This allows some IK solvers, including the default KDL solver in MoveIt!, to load much faster by passing in a pre-loaded robot model instead of loading and parsing one from the parameter server each time an IK solver is initialized. This is important because multiple IK solvers are loaded, typically one for each planning group and again for each MoveIt! node. This does not currently improve loading time of IKFast solvers, however, because those robot models must be converted to Collada format and parsed by openrave. 

Changes:
- Passes a pointer to a RobotModel, or a Null pointer for backwards compatibility. 
- Deprecated initialize() function that does not use RobotModel
- Added `getParentModelPtr()` to joint model group
- Added `boost::enable_shared_from_this` to allow the shared pointer to be recieved by objects that only have its raw pointer

Additionally, KinematicsBase is now forward declaring RobotState and RobotModel, so @isucan suggested:

> To resolve cyclic dependency between libs, we should probably put everything in moveit_core into one lib.

I have not done this yet, but am thinking I could create a new library `moveit_core` that includes `moveit_robot_model`, `moveit_robot_state`, and `moveit_kinematics_base`. Thoughts? It still currently compiles without this last change though.
