### PR TITLE
Planning Scene: Ability to offset geometry loaded from stream

### DIFF
--- a/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -658,6 +658,9 @@ public:
   
   /** \brief Load the geometry of the planning scene from a stream */
   void loadGeometryFromStream(std::istream &in);
+
+  /** \brief Load the geometry of the planning scene from a stream at a certain location using offset*/
+  void loadGeometryFromStream(std::istream &in, const Eigen::Affine3d &offset);
   
   /** \brief Fill the message \e scene with the differences between this instance of PlanningScene with respect to the parent.
       If there is no parent, everything is considered to be a diff and the function behaves like getPlanningSceneMsg() */

--- a/planning_scene/src/planning_scene.cpp
+++ b/planning_scene/src/planning_scene.cpp
@@ -985,6 +985,11 @@ void planning_scene::PlanningScene::saveGeometryToStream(std::ostream &out) cons
 
 void planning_scene::PlanningScene::loadGeometryFromStream(std::istream &in)
 {
+  loadGeometryFromStream(in, Eigen::Affine3d::Identity()); // Use no offset
+}
+
+void planning_scene::PlanningScene::loadGeometryFromStream(std::istream &in, const Eigen::Affine3d &offset)
+{
   if (!in.good() || in.eof())
     return;
   std::getline(in, name_);
@@ -1014,6 +1019,8 @@ void planning_scene::PlanningScene::loadGeometryFromStream(std::istream &in)
         if (s)
         {
           Eigen::Affine3d pose = Eigen::Translation3d(x, y, z) * Eigen::Quaterniond(rw, rx, ry, rz);
+          // Transform pose by input pose offset
+          pose = offset * pose;
           world_->addToObject(ns, shapes::ShapePtr(s), pose);
           if (r > 0.0f || g > 0.0f || b > 0.0f || a > 0.0f)
           {


### PR DESCRIPTION
When loading a planning scene from file, this allows a pose to be provided to place that scene in a different location.
