### PR TITLE
Added ability to remove all collision objects directly through API

### DIFF
--- a/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -691,6 +691,11 @@ public:
   void processOctomapMsg(const octomap_msgs::Octomap &map);
   void processOctomapPtr(const boost::shared_ptr<const octomap::OcTree> &octree, const Eigen::Affine3d &t);
 
+  /**
+   * \brief Clear all collision objects in planning scene
+   */
+  void removeAllCollisionObjects();
+
   /** \brief Set the current robot state to be \e state. If not
       all joint values are specified, the previously maintained
       joint values are kept. */

--- a/planning_scene/src/planning_scene.cpp
+++ b/planning_scene/src/planning_scene.cpp
@@ -1258,6 +1258,14 @@ void planning_scene::PlanningScene::processOctomapMsg(const octomap_msgs::Octoma
   }
 }
 
+void planning_scene::PlanningScene::removeAllCollisionObjects()
+{
+  const std::vector<std::string> &object_ids = world_->getObjectIds();
+  for (std::size_t i = 0; i < object_ids.size(); ++i)
+    if (object_ids[i] != OCTOMAP_NS)
+      world_->removeObject(object_ids[i]);
+}
+
 void planning_scene::PlanningScene::processOctomapMsg(const octomap_msgs::OctomapWithPose &map)
 {
   // each octomap replaces any previous one
@@ -1622,10 +1630,7 @@ bool planning_scene::PlanningScene::processCollisionObjectMsg(const moveit_msgs:
   {
     if (object.id.empty())
     {
-      const std::vector<std::string> &object_ids = world_->getObjectIds();
-      for (std::size_t i = 0; i < object_ids.size(); ++i)
-        if (object_ids[i] != OCTOMAP_NS)
-          world_->removeObject(object_ids[i]);
+      removeAllCollisionObjects();
     }
     else
       world_->removeObject(object.id);


### PR DESCRIPTION
Currently if you want to remove all collision objects from a planning scene you have to create a ROS collision objects message then have the planning scene process it. This allows direct access, moving the current message processing code out into a re-usable function. Does not change any behavior.

(I'm using this in moveit_visual_tools)
