### PR TITLE
KinematicsBase  changes

### DIFF
--- a/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -56,6 +56,19 @@ class RobotState;
 namespace kinematics
 {
 
+namespace KinematicsSolution
+{
+  enum KinematicsSolutionSearch
+  {
+    ONE = 1,
+    ALL_DISCRETIZED ,
+    SOME_DISCRETIZED,
+    RANDOM_SAMPLE,
+    ALL
+  };
+}
+typedef KinematicsSolution::KinematicsSolutionSearch KinematicsSolutionSearch;
+
 /**
  * @struct KinematicsQueryOptions
  * @brief A set of options for the kinematics solver
@@ -101,6 +114,12 @@ public:
                              std::vector<double> &solution,
                              moveit_msgs::MoveItErrorCodes &error_code,
                              const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const = 0;
+
+  virtual bool getMultipleIK(const geometry_msgs::Pose &ik_pose,
+                             std::vector< std::vector<double> >& solutions,
+                             moveit_msgs::MoveItErrorCodes &error_code,
+                             double& solution_percentage,
+                             const kinematics::KinematicsQueryOptions &options) const;
 
   /**
    * @brief Given a desired pose of the end-effector, search for the joint angles required to reach it.

--- a/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -563,7 +563,7 @@ public:
     }
     else
     {
-      return 0.0f; // returned when there aren't any redundant joints
+      return 0.0; // returned when there aren't any redundant joints
     }
   }
 
@@ -571,7 +571,7 @@ public:
    * @brief Returns the set of supported kinematics discretization search types.  This implementation only supports
    * the DiscretizationMethods::ONE search.
    */
-  std::vector<DiscretizationMethod> getSuportedDiscretizationMethods() const
+  std::vector<DiscretizationMethod> getSupportedDiscretizationMethods() const
   {
     return supported_methods_;
   }

--- a/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -88,7 +88,7 @@ namespace KinematicErrors
     UNSUPORTED_DISCRETIZATION_REQUESTED,        /**< Discretization method isn't supported by this implementation */
     DISCRETIZATION_NOT_INITIALIZED,             /**< Discretization values for the redundancy has not been set. See
                                                      setSearchDiscretization(...) method*/
-    MULTIPLE_TIPS_NO_SUPPORTED,                 /**< Only single tip link support is allowed */
+    MULTIPLE_TIPS_NOT_SUPPORTED,                 /**< Only single tip link support is allowed */
     EMPTY_TIP_POSES,                            /**< Empty ik_poses array passed */
     NO_SOLUTION                                 /**< A valid joint solution that can reach this pose(s) could not be found */
 

--- a/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -90,6 +90,8 @@ namespace KinematicErrors
                                                      setSearchDiscretization(...) method*/
     MULTIPLE_TIPS_NOT_SUPPORTED,                 /**< Only single tip link support is allowed */
     EMPTY_TIP_POSES,                            /**< Empty ik_poses array passed */
+    IK_SEED_OUTSIDE_LIMITS,                                /**< Ik seed is out of bounds*/
+    SOLVER_NOT_ACTIVE,                          /**< Solver isn't active */
     NO_SOLUTION                                 /**< A valid joint solution that can reach this pose(s) could not be found */
 
   };
@@ -166,6 +168,7 @@ public:
    * 'getPositionIK(...)' with a zero initialized seed.
    *
    * @param ik_poses  The desired pose of each tip link
+   * @param ik_seed_state an initial guess solution for the inverse kinematics
    * @param solutions A vector of vectors where each entry is a valid joint solution
    * @param result A struct that reports the results of the query
    * @param options An option struct which contains the type of redundancy discretization used. This default
@@ -174,6 +177,7 @@ public:
    * @return True if a valid set of solutions was found, false otherwise.
    */
   virtual bool getPositionIK(const std::vector<geometry_msgs::Pose> &ik_poses,
+                             const std::vector<double> &ik_seed_state,
                              std::vector< std::vector<double> >& solutions,
                              KinematicsResult& result,
                              const kinematics::KinematicsQueryOptions &options) const;

--- a/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -165,11 +165,11 @@ public:
    * This is a default implementation that returns only one solution and so its result is equivalent to calling
    * 'getPositionIK(...)' with a zero initialized seed.
    *
-   * @param ik_pose The desired pose of the tip frame
+   * @param ik_poses  The desired pose of each tip link
    * @param solutions A vector of vectors where each entry is a valid joint solution
    * @param result A struct that reports the results of the query
    * @param options An option struct which contains the type of redundancy discretization used. This default
-   *                implementation only supports the KinmaticSearches::NO_DISCRETIZATION method; requesting any
+   *                implementation only supports the KinematicSearches::NO_DISCRETIZATION method; requesting any
    *                other will result in failure.
    * @return True if a valid set of solutions was found, false otherwise.
    */

--- a/kinematics_base/src/kinematics_base.cpp
+++ b/kinematics_base/src/kinematics_base.cpp
@@ -128,12 +128,12 @@ bool kinematics::KinematicsBase::supportsGroup(const moveit::core::JointModelGro
 }
 
 bool kinematics::KinematicsBase::getPositionIK(const std::vector<geometry_msgs::Pose> &ik_poses,
+                           const std::vector<double> &ik_seed_state,
                            std::vector< std::vector<double> >& solutions,
                            kinematics::KinematicsResult& result,
                            const kinematics::KinematicsQueryOptions &options) const
 {
   std::vector<double> solution;
-  std::vector<double> seed(getJointNames().size(),0.0);
   result.solution_percentage = 0.0;
 
   bool supported = false;
@@ -160,7 +160,7 @@ bool kinematics::KinematicsBase::getPositionIK(const std::vector<geometry_msgs::
 
 
   moveit_msgs::MoveItErrorCodes error_code;
-  if(getPositionIK(ik_poses[0],seed,solution,error_code,options))
+  if(getPositionIK(ik_poses[0],ik_seed_state,solution,error_code,options))
   {
     solutions.resize(1);
     solutions[0] = solution;

--- a/kinematics_base/src/kinematics_base.cpp
+++ b/kinematics_base/src/kinematics_base.cpp
@@ -133,8 +133,8 @@ bool kinematics::KinematicsBase::getPositionIK(const std::vector<geometry_msgs::
                            const kinematics::KinematicsQueryOptions &options) const
 {
   std::vector<double> solution;
-  std::vector<double> seed(getJointNames().size(),0.0f);
-  result.solution_percentage = 0.0f;
+  std::vector<double> seed(getJointNames().size(),0.0);
+  result.solution_percentage = 0.0;
 
   bool supported = false;
   if(std::find(supported_methods_.begin(),supported_methods_.end(),options.discretization_method) ==

--- a/kinematics_base/src/kinematics_base.cpp
+++ b/kinematics_base/src/kinematics_base.cpp
@@ -122,3 +122,35 @@ bool kinematics::KinematicsBase::supportsGroup(const moveit::core::JointModelGro
 
   return true;
 }
+
+bool kinematics::KinematicsBase::getMultipleIK(const geometry_msgs::Pose &ik_pose,
+                           std::vector< std::vector<double> >& solutions,
+                           kinematics::KinematicsResult& result,
+                           const kinematics::KinematicsQueryOptions &options) const
+{
+  std::vector<double> solution;
+  std::vector<double> seed(getJointNames().size(),0.0f);
+  result.solution_percentage = 0.0f;
+
+  if(options.solutions_search_code != KinematicSearches::ONE)
+  {
+    result.kinematic_error = kinematics::KinematicErrors::UNSUPORTED_SEARCH_REQUESTED;
+    return false;
+  }
+
+  moveit_msgs::MoveItErrorCodes error_code;
+  if(getPositionIK(ik_pose,seed,solution,error_code,options))
+  {
+    solutions.resize(1);
+    solutions[0] = solution;
+    result.kinematic_error = kinematics::KinematicErrors::OK;
+    result.solution_percentage = 1.0f;
+  }
+  else
+  {
+    result.kinematic_error = kinematics::KinematicErrors::NO_SOLUTION;
+    return false;
+  }
+
+  return true;
+}

--- a/kinematics_base/src/kinematics_base.cpp
+++ b/kinematics_base/src/kinematics_base.cpp
@@ -147,7 +147,7 @@ bool kinematics::KinematicsBase::getPositionIK(const std::vector<geometry_msgs::
   if(ik_poses.size() != 1)
   {
     logError("moveit.kinematics_base: This kinematic solver does not support getPositionIK for multiple poses");
-    result.kinematic_error = kinematics::KinematicErrors::MULTIPLE_TIPS_NO_SUPPORTED;
+    result.kinematic_error = kinematics::KinematicErrors::MULTIPLE_TIPS_NOT_SUPPORTED;
     return false;
   }
 


### PR DESCRIPTION
This PR follows from the discussion [here](https://groups.google.com/forum/#!searchin/moveit-users/Proposed$20Change$20to$20IK$20plugin$20definition/moveit-users/IGkUhU2CGu0/nHIMJ5TTOFIJ) in regards to extending KinematicsBase class in order to support finding/returning multiple IK solutions for a single tip pose. 
In summary, the important changes introduced here are as follows:
- Added a getMultipleIk(..) non pure virtual method which allows returning multiple joint solutions.  The default implementation here just makes a call to the getPositionIK method.  Implementations of this base class shall return several solutions when available.
- Created a "KinematicsSearch" enumeration containing flags for choosing how to discretize the redundant joints when finding the ik solutions for a tip pose.
- Created the  "KinematicsErrors" enumeration that provides supplementary error codes indicating the type of failure during a kinematics query.
- Added the setJointDiscretization() method that sets the discretization for each redundant joint.
