### PR TITLE
fix_type_qualifiers_compiler_warnings

### DIFF
--- a/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -440,7 +440,7 @@ public:
    *          supported.
    * \return True if the group is supported, false if not.
    */
-  virtual const bool supportsGroup(const moveit::core::JointModelGroup *jmg,
+  virtual bool supportsGroup(const moveit::core::JointModelGroup *jmg,
                                    std::string* error_text_out = NULL) const;
 
   /**

--- a/kinematics_base/src/kinematics_base.cpp
+++ b/kinematics_base/src/kinematics_base.cpp
@@ -107,7 +107,7 @@ std::string kinematics::KinematicsBase::removeSlash(const std::string &str) cons
   return (!str.empty() && str[0] == '/') ? removeSlash(str.substr(1)) : str;
 }
 
-const bool kinematics::KinematicsBase::supportsGroup(const moveit::core::JointModelGroup *jmg,
+bool kinematics::KinematicsBase::supportsGroup(const moveit::core::JointModelGroup *jmg,
                                                      std::string* error_text_out) const
 {
   // Default implementation for legacy solvers:

--- a/robot_state/include/moveit/robot_state/robot_state.h
+++ b/robot_state/include/moveit/robot_state/robot_state.h
@@ -190,7 +190,7 @@ public:
   }
   
   /** \brief Get the position of a particular variable. An exception is thrown if the variable is not known. */
-  const double getVariablePosition(const std::string &variable) const
+  double getVariablePosition(const std::string &variable) const
   {
     return position_[robot_model_->getVariableIndex(variable)];
   }
@@ -198,7 +198,7 @@ public:
   /** \brief Get the position of a particular variable. The variable is
       specified by its index. No checks are performed for the validity
       of the index passed  */  
-  const double getVariablePosition(int index) const
+  double getVariablePosition(int index) const
   {
     return position_[index];
   }
@@ -269,7 +269,7 @@ public:
   }
   
   /** \brief Get the velocity of a particular variable. An exception is thrown if the variable is not known. */
-  const double getVariableVelocity(const std::string &variable) const
+  double getVariableVelocity(const std::string &variable) const
   {
     return velocity_[robot_model_->getVariableIndex(variable)];
   }
@@ -277,7 +277,7 @@ public:
   /** \brief Get the velocity of a particular variable. The variable is
       specified by its index. No checks are performed for the validity
       of the index passed  */  
-  const double getVariableVelocity(int index) const
+  double getVariableVelocity(int index) const
   {
     return velocity_[index];
   }
@@ -350,7 +350,7 @@ public:
   }
   
   /** \brief Get the acceleration of a particular variable. An exception is thrown if the variable is not known. */
-  const double getVariableAcceleration(const std::string &variable) const
+  double getVariableAcceleration(const std::string &variable) const
   {
     return acceleration_[robot_model_->getVariableIndex(variable)];
   }
@@ -358,7 +358,7 @@ public:
   /** \brief Get the acceleration of a particular variable. The variable is
       specified by its index. No checks are performed for the validity
       of the index passed  */    
-  const double getVariableAcceleration(int index) const
+  double getVariableAcceleration(int index) const
   {
     return acceleration_[index];
   }
@@ -430,7 +430,7 @@ public:
   }
 
   /** \brief Get the effort of a particular variable. An exception is thrown if the variable is not known. */  
-  const double getVariableEffort(const std::string &variable) const
+  double getVariableEffort(const std::string &variable) const
   {
     return effort_[robot_model_->getVariableIndex(variable)];
   }
@@ -438,7 +438,7 @@ public:
   /** \brief Get the effort of a particular variable. The variable is
       specified by its index. No checks are performed for the validity
       of the index passed  */      
-  const double getVariableEffort(int index) const
+  double getVariableEffort(int index) const
   {
     return effort_[index];
   }


### PR DESCRIPTION
The gcc-compiler warns that the "const" qualifier is ignored when
returning by value. This patch removes unnecessary qualifiers and
compiler warnings emerging from them. It does not have any effect on the
functionality of the code.
