### PR TITLE
API Change of shape_tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,6 @@ COMPONENTS
   srdfdom
   kdl_parser
   geometric_shapes
-  shape_tools
   eigen_stl_containers 
   eigen_conversions
   random_numbers
@@ -90,7 +89,6 @@ catkin_package(
     ${OCTOMAP_LIBRARIES}
   CATKIN_DEPENDS
     geometric_shapes
-    shape_tools
     eigen_stl_containers
     eigen_conversions
     random_numbers

--- a/kinematic_constraints/src/utils.cpp
+++ b/kinematic_constraints/src/utils.cpp
@@ -35,7 +35,7 @@
 /* Author: Ioan Sucan */
 
 #include <moveit/kinematic_constraints/utils.h>
-#include <shape_tools/solid_primitive_dims.h>
+#include <geometric_shapes/solid_primitive_dims.h>
 
 moveit_msgs::Constraints kinematic_constraints::mergeConstraints(const moveit_msgs::Constraints &first, const moveit_msgs::Constraints &second)
 {
@@ -154,7 +154,7 @@ moveit_msgs::Constraints kinematic_constraints::constructGoalConstraints(const s
   pcm.constraint_region.primitives.resize(1);
   shape_msgs::SolidPrimitive &bv = pcm.constraint_region.primitives[0];
   bv.type = shape_msgs::SolidPrimitive::SPHERE;
-  bv.dimensions.resize(shape_tools::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::SPHERE>::value);
+  bv.dimensions.resize(geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::SPHERE>::value);
   bv.dimensions[shape_msgs::SolidPrimitive::SPHERE_RADIUS] = tolerance_pos;
 
   pcm.header = pose.header;
@@ -189,7 +189,7 @@ moveit_msgs::Constraints kinematic_constraints::constructGoalConstraints(const s
   {
     shape_msgs::SolidPrimitive &bv = goal.position_constraints[0].constraint_region.primitives[0];
     bv.type = shape_msgs::SolidPrimitive::BOX;
-    bv.dimensions.resize(shape_tools::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::BOX>::value);
+    bv.dimensions.resize(geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::BOX>::value);
     bv.dimensions[shape_msgs::SolidPrimitive::BOX_X] = tolerance_pos[0];
     bv.dimensions[shape_msgs::SolidPrimitive::BOX_Y] = tolerance_pos[1];
     bv.dimensions[shape_msgs::SolidPrimitive::BOX_Z] = tolerance_pos[2];
@@ -239,7 +239,7 @@ moveit_msgs::Constraints kinematic_constraints::constructGoalConstraints(const s
   pcm.target_point_offset.z = reference_point.z;
   pcm.constraint_region.primitives.resize(1);
   pcm.constraint_region.primitives[0].type = shape_msgs::SolidPrimitive::SPHERE;
-  pcm.constraint_region.primitives[0].dimensions.resize(shape_tools::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::SPHERE>::value);
+  pcm.constraint_region.primitives[0].dimensions.resize(geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::SPHERE>::value);
   pcm.constraint_region.primitives[0].dimensions[shape_msgs::SolidPrimitive::SPHERE_RADIUS] = tolerance;
 
   pcm.header = goal_point.header;

--- a/kinematic_constraints/src/utils.cpp
+++ b/kinematic_constraints/src/utils.cpp
@@ -35,7 +35,8 @@
 /* Author: Ioan Sucan */
 
 #include <moveit/kinematic_constraints/utils.h>
-#include <shape_tools/solid_primitive_dims.h>
+#include <geometric_shapes/solid_primitive_dims.h>
+#include <eigen_conversions/eigen_msg.h>
 
 moveit_msgs::Constraints kinematic_constraints::mergeConstraints(const moveit_msgs::Constraints &first, const moveit_msgs::Constraints &second)
 {
@@ -154,7 +155,7 @@ moveit_msgs::Constraints kinematic_constraints::constructGoalConstraints(const s
   pcm.constraint_region.primitives.resize(1);
   shape_msgs::SolidPrimitive &bv = pcm.constraint_region.primitives[0];
   bv.type = shape_msgs::SolidPrimitive::SPHERE;
-  bv.dimensions.resize(shape_tools::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::SPHERE>::value);
+  bv.dimensions.resize(geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::SPHERE>::value);
   bv.dimensions[shape_msgs::SolidPrimitive::SPHERE_RADIUS] = tolerance_pos;
 
   pcm.header = pose.header;
@@ -189,7 +190,7 @@ moveit_msgs::Constraints kinematic_constraints::constructGoalConstraints(const s
   {
     shape_msgs::SolidPrimitive &bv = goal.position_constraints[0].constraint_region.primitives[0];
     bv.type = shape_msgs::SolidPrimitive::BOX;
-    bv.dimensions.resize(shape_tools::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::BOX>::value);
+    bv.dimensions.resize(geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::BOX>::value);
     bv.dimensions[shape_msgs::SolidPrimitive::BOX_X] = tolerance_pos[0];
     bv.dimensions[shape_msgs::SolidPrimitive::BOX_Y] = tolerance_pos[1];
     bv.dimensions[shape_msgs::SolidPrimitive::BOX_Z] = tolerance_pos[2];
@@ -239,7 +240,7 @@ moveit_msgs::Constraints kinematic_constraints::constructGoalConstraints(const s
   pcm.target_point_offset.z = reference_point.z;
   pcm.constraint_region.primitives.resize(1);
   pcm.constraint_region.primitives[0].type = shape_msgs::SolidPrimitive::SPHERE;
-  pcm.constraint_region.primitives[0].dimensions.resize(shape_tools::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::SPHERE>::value);
+  pcm.constraint_region.primitives[0].dimensions.resize(geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::SPHERE>::value);
   pcm.constraint_region.primitives[0].dimensions[shape_msgs::SolidPrimitive::SPHERE_RADIUS] = tolerance;
 
   pcm.header = goal_point.header;

--- a/package.xml
+++ b/package.xml
@@ -26,7 +26,6 @@
   <build_depend>liburdfdom-dev</build_depend>
   <build_depend>liburdfdom-headers-dev</build_depend>
   <build_depend>random_numbers</build_depend>
-  <build_depend>shape_tools</build_depend>
   <build_depend>octomap_msgs</build_depend>  
   <build_depend>moveit_msgs</build_depend>
   <build_depend>actionlib_msgs</build_depend>
@@ -56,7 +55,6 @@
   <run_depend>liburdfdom-dev</run_depend>
   <run_depend>liburdfdom-headers-dev</run_depend>
   <run_depend>random_numbers</run_depend>
-  <run_depend>shape_tools</run_depend>
   <run_depend>octomap</run_depend>
   <run_depend>srdfdom</run_depend> 
   <run_depend>kdl_parser</run_depend>


### PR DESCRIPTION
Permeating [deprecation of shape_tools](https://github.com/ros-planning/geometric_shapes/pull/32) throughout moveit_*
