### PR TITLE
New getOnlyOneEndEffectorTip() function

### DIFF
--- a/robot_model/include/moveit/robot_model/joint_model_group.h
+++ b/robot_model/include/moveit/robot_model/joint_model_group.h
@@ -485,6 +485,13 @@ public:
    */
   bool getEndEffectorTips(std::vector<std::string> &tips) const;
 
+  /**
+   * \brief Get one end effector tip, throwing an error if there ends up being more in the joint model group
+   *  This is a useful helper function because most planning groups (almost all) only have one tip
+   * \return pointer to LinkModel, or NULL on failure
+   */
+  const moveit::core::LinkModel* getOnlyOneEndEffectorTip() const;
+
   /** \brief Get the bounds for all the active joints */
   const JointBoundsVector& getActiveJointModelsBounds() const
   {

--- a/robot_model/src/joint_model_group.cpp
+++ b/robot_model/src/joint_model_group.cpp
@@ -514,6 +514,19 @@ bool moveit::core::JointModelGroup::getEndEffectorTips(std::vector<const LinkMod
   return true;
 }
 
+const moveit::core::LinkModel* moveit::core::JointModelGroup::getOnlyOneEndEffectorTip() const
+{
+  std::vector<const moveit::core::LinkModel*> tips;
+  getEndEffectorTips(tips);
+  if (tips.size() == 1)
+    return tips.front();
+  else if (tips.size() > 1)
+    logError("More than one end effector tip found for joint model group, so cannot return only one");
+  else
+    logError("No end effector tips found in joint model group");
+  return NULL;
+}
+
 int moveit::core::JointModelGroup::getVariableGroupIndex(const std::string &variable) const
 {
   VariableIndexMap::const_iterator it = joint_variables_index_map_.find(variable);


### PR DESCRIPTION
If you want to quickly solve a IK problem on the tip link of a joint model group using its end effector semantics, this is a helpful shortcut function
