### PR TITLE
Fix issue #258 in indigo-devel

### DIFF
--- a/collision_detection_fcl/src/collision_common.cpp
+++ b/collision_detection_fcl/src/collision_common.cpp
@@ -364,6 +364,10 @@ bool distanceCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void* 
   const CollisionGeometryData* cd1 = static_cast<const CollisionGeometryData*>(o1->collisionGeometry()->getUserData());
   const CollisionGeometryData* cd2 = static_cast<const CollisionGeometryData*>(o2->collisionGeometry()->getUserData());
 
+  // do not perform distance calculation for geoms part of the same object / link / attached body
+  if (cd1->sameObject(*cd2))
+    return false;
+
   // If active components are specified
   if (cdata->active_components_only_)
   {


### PR DESCRIPTION
This addresses issue #258: When requesting distance information for urdf's that have links with multiple geometries, an incorrect distance is returned. This is a result of the distanceCallback function not checking if both geometries are associated to the same object as done in the [collisionCallback](https://github.com/ros-planning/moveit_core/blob/indigo-devel/collision_detection_fcl/src/collision_common.cpp#L54-L56).
