### PR TITLE
Indigo: setJointVelocity and setJointEffort functions

### DIFF
--- a/robot_state/include/moveit/robot_state/robot_state.h
+++ b/robot_state/include/moveit/robot_state/robot_state.h
@@ -482,6 +482,24 @@ public:
     updateMimicJoint(joint);
   }
   
+  void setJointVelocities(const JointModel *joint, const double *velocity)
+  {
+    has_velocity_ = true;
+    memcpy(velocity_ + joint->getFirstVariableIndex(), velocity, joint->getVariableCount() * sizeof(double));
+  }
+
+  void setJointEfforts(const JointModel *joint, const double *effort)
+  {
+    if (has_acceleration_)
+    {
+      logError("Unable to set joint efforts because array is being used for accelerations");
+      return;
+    }
+    has_effort_ = true;
+
+    memcpy(effort_ + joint->getFirstVariableIndex(), effort, joint->getVariableCount() * sizeof(double));
+  }
+
   const double* getJointPositions(const std::string &joint_name) const
   {
     return getJointPositions(robot_model_->getJointModel(joint_name));


### PR DESCRIPTION
Syncing two new functions added to Jade that would be nice in Indigo also. Already merged in Jade here: https://github.com/ros-planning/moveit_core/pull/261
