### PR TITLE
Send Octomap diff instead of whole tree

### DIFF
--- a/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -98,6 +98,8 @@ public:
                 collision_detection::WorldPtr world = collision_detection::WorldPtr(new collision_detection::World()));
 
   static const std::string OCTOMAP_NS;
+  static const std::string OCTOMAP_MSG_TYPE;
+  static const std::string OCTOMAP_DIFF_MSG_TYPE;
   static const std::string DEFAULT_SCENE_NAME;
 
   ~PlanningScene();
@@ -693,6 +695,7 @@ public:
   void processOctomapMsg(const octomap_msgs::OctomapWithPose &map);
   void processOctomapMsg(const octomap_msgs::Octomap &map);
   void processOctomapMsg(const octomap_msgs::Octomap &map, const Eigen::Affine3d &t);
+  void processOctomapMsgDiff(const octomap_msgs::Octomap &map, boost::shared_ptr<octomap::OcTree> octree);
   void processOctomapPtr(const boost::shared_ptr<const octomap::OcTree> &octree, const Eigen::Affine3d &t);
 
   /**
@@ -891,6 +894,7 @@ private:
   void getPlanningSceneMsgCollisionObject(moveit_msgs::PlanningScene &scene, const std::string &ns) const;
   void getPlanningSceneMsgCollisionObjects(moveit_msgs::PlanningScene &scene) const;
   void getPlanningSceneMsgOctomap(moveit_msgs::PlanningScene &scene) const;
+  bool getPlanningSceneMsgOctomapDiff(boost::shared_ptr<const octomap::OcTree> octree, octomap_msgs::Octomap &msg) const;
   void getPlanningSceneMsgObjectColors(moveit_msgs::PlanningScene &scene_msg) const;
 
   struct CollisionDetector;

--- a/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -692,6 +692,7 @@ public:
 
   void processOctomapMsg(const octomap_msgs::OctomapWithPose &map);
   void processOctomapMsg(const octomap_msgs::Octomap &map);
+  void processOctomapMsg(const octomap_msgs::Octomap &map, const Eigen::Affine3d &t);
   void processOctomapPtr(const boost::shared_ptr<const octomap::OcTree> &octree, const Eigen::Affine3d &t);
 
   /**

--- a/planning_scene/src/planning_scene.cpp
+++ b/planning_scene/src/planning_scene.cpp
@@ -899,7 +899,7 @@ bool planning_scene::PlanningScene::getPlanningSceneMsgOctomapDiff(boost::shared
       datastream.write((const char*) &key[j], sizeof(unsigned short int));
     }
     float value = octree->search(key)->getLogOdds();
-    datastream.write((const char*) &value, sizeof(int));
+    datastream.write((const char*) &value, sizeof(float));
   }
 
   if (!datastream)

--- a/planning_scene/src/planning_scene.cpp
+++ b/planning_scene/src/planning_scene.cpp
@@ -1239,32 +1239,6 @@ void planning_scene::PlanningScene::usePlanningSceneMsg(const moveit_msgs::Plann
     setPlanningSceneMsg(scene_msg);
 }
 
-void planning_scene::PlanningScene::processOctomapMsg(const octomap_msgs::Octomap &map)
-{
-  // each octomap replaces any previous one
-  world_->removeObject(OCTOMAP_NS);
-
-  if (map.data.empty())
-    return;
-
-  if (map.id != "OcTree")
-  {
-    logError("Received ocomap is of type '%s' but type 'OcTree' is expected.", map.id.c_str());
-    return;
-  }
-
-  boost::shared_ptr<octomap::OcTree> om(static_cast<octomap::OcTree*>(octomap_msgs::msgToMap(map)));
-  if (!map.header.frame_id.empty())
-  {
-    const Eigen::Affine3d &t = getTransforms().getTransform(map.header.frame_id);
-    world_->addToObject(OCTOMAP_NS, shapes::ShapeConstPtr(new shapes::OcTree(om)), t);
-  }
-  else
-  {
-    world_->addToObject(OCTOMAP_NS, shapes::ShapeConstPtr(new shapes::OcTree(om)), Eigen::Affine3d::Identity());
-  }
-}
-
 void planning_scene::PlanningScene::removeAllCollisionObjects()
 {
   const std::vector<std::string> &object_ids = world_->getObjectIds();
@@ -1275,24 +1249,44 @@ void planning_scene::PlanningScene::removeAllCollisionObjects()
 
 void planning_scene::PlanningScene::processOctomapMsg(const octomap_msgs::OctomapWithPose &map)
 {
-  // each octomap replaces any previous one
-  world_->removeObject(OCTOMAP_NS);
-
-  if (map.octomap.data.empty())
-    return;
-
-  if (map.octomap.id != "OcTree")
-  {
-    logError("Received ocomap is of type '%s' but type 'OcTree' is expected.", map.octomap.id.c_str());
-    return;
-  }
-
-  boost::shared_ptr<octomap::OcTree> om(static_cast<octomap::OcTree*>(octomap_msgs::msgToMap(map.octomap)));
   const Eigen::Affine3d &t = getTransforms().getTransform(map.header.frame_id);
   Eigen::Affine3d p;
   tf::poseMsgToEigen(map.origin, p);
   p = t * p;
-  world_->addToObject(OCTOMAP_NS, shapes::ShapeConstPtr(new shapes::OcTree(om)), p);
+  processOctomapMsg(map.octomap, p);
+}
+
+void planning_scene::PlanningScene::processOctomapMsg(const octomap_msgs::Octomap &map)
+{
+  if (!map.header.frame_id.empty())
+  {
+    const Eigen::Affine3d &t = getTransforms().getTransform(map.header.frame_id);
+    processOctomapMsg(map, t);
+  }
+  else
+  {
+    processOctomapMsg(map, Eigen::Affine3d::Identity());
+  }
+}
+
+void planning_scene::PlanningScene::processOctomapMsg(const octomap_msgs::Octomap &map, const Eigen::Affine3d &t)
+{
+  if (map.id.empty())
+  {
+    world_->removeObject(OCTOMAP_NS);
+  }
+  else if (map.id == "OcTree")
+  {
+    world_->removeObject(OCTOMAP_NS); // Octomap replaces any previous one
+    if (map.data.empty())
+      return;
+    boost::shared_ptr<octomap::OcTree> om(static_cast<octomap::OcTree*>(octomap_msgs::msgToMap(map)));
+    world_->addToObject(OCTOMAP_NS, shapes::ShapeConstPtr(new shapes::OcTree(om)), t);
+  }
+  else
+  {
+    logError("Received Octomap is of unknown type '%s'", map.id.c_str());
+  }
 }
 
 void planning_scene::PlanningScene::processOctomapPtr(const boost::shared_ptr<const octomap::OcTree> &octree, const Eigen::Affine3d &t)

--- a/planning_scene/src/planning_scene.cpp
+++ b/planning_scene/src/planning_scene.cpp
@@ -864,6 +864,10 @@ void planning_scene::PlanningScene::getPlanningSceneMsgOctomap(moveit_msgs::Plan
         {
           logInform("Cheaper to send tree instead of diff by %i bytes with %i changes", expected_size_diff-expected_size_tree, octree->numChangesDetected());
           octomap_msgs::fullMapToMsg(*octree, scene_msg.world.octomap.octomap);
+          if(scene_msg.world.octomap.octomap.id != OCTOMAP_MSG_TYPE) {
+            logWarn("fullMapToMsg produced unexpected octomap type: %s",
+                    scene_msg.world.octomap.octomap.id.c_str());
+          }
         }
         else
         {
@@ -871,7 +875,13 @@ void planning_scene::PlanningScene::getPlanningSceneMsgOctomap(moveit_msgs::Plan
         }
       }
       else
+      {
         octomap_msgs::fullMapToMsg(*octree, scene_msg.world.octomap.octomap);
+        if(scene_msg.world.octomap.octomap.id != OCTOMAP_MSG_TYPE) {
+          logWarn("fullMapToMsg produced unexpected octomap type: %s",
+                  scene_msg.world.octomap.octomap.id.c_str());
+        }
+      }
       tf::poseEigenToMsg(map->shape_poses_[0], scene_msg.world.octomap.origin);
     }
     else
@@ -1367,6 +1377,9 @@ void planning_scene::PlanningScene::processOctomapMsgDiff(const octomap_msgs::Oc
   {
     logError("Did not receive enough data for specified diff size: %i bytes expected, %i received", expected_size, msg.data.size());
     return;
+  }
+  if(expected_size < msg.data.size()) {
+      logWarn("Got more data than expected (%zu > %d)", msg.data.size(), expected_size);
   }
 
   for (int i=0; i<num_changes && !(!datastream); ++i)


### PR DESCRIPTION
This is essentially ros-planning/moveit_core#255 by @TheBrewCrew with some minor fixes.

The main reason is that in indigo we can only depend on OctoMap/octomap#103 and not OctoMap/octomap#85. This is handled in 28a6eb4. OctoMap/octomap#103 is already released as 1.6.9 in indigo (currently only shadow-fixed) and thus this can be merged once it is active.

I have left my additions as individual commits, so it is clear for reviewing this, what I changed.
I can also squash them in the original commits before merging, if someone gives me the go-ahead.

The corresponding pull request is moveit_ros is ros-planning/moveit_ros#636.
