### PR TITLE
Fix memory leak in RobotState::attachBody

### DIFF
--- a/robot_state/src/robot_state.cpp
+++ b/robot_state/src/robot_state.cpp
@@ -69,6 +69,7 @@ moveit::core::RobotState::RobotState(const RobotState &other)
 
 moveit::core::RobotState::~RobotState()
 {
+  clearAttachedBodies();
   free(memory_);
   if (rng_)
     delete rng_;


### PR DESCRIPTION
This fixes bug #275
