### PR TITLE
getStateAtDurationFromStart would never execute, fix

### DIFF
--- a/robot_trajectory/src/robot_trajectory.cpp
+++ b/robot_trajectory/src/robot_trajectory.cpp
@@ -399,7 +399,8 @@ double robot_trajectory::RobotTrajectory::getWaypointDurationFromStart(std::size
 
 bool robot_trajectory::RobotTrajectory::getStateAtDurationFromStart(const double request_duration, robot_state::RobotStatePtr& output_state) const
 {
-  if (!getWayPointCount())
+  // If there are no waypoints we can't do anything
+  if (getWayPointCount())
     return false;
 
   int before = 0, after = 0;


### PR DESCRIPTION
I would like to point out that for this method to be really useful (I discovered it while trying to use it) I think it should look like:

``` c++
bool robot_trajectory::RobotTrajectory::getStateAtDurationFromStart(const double request_duration, robot_state::RobotStatePtr& output_state, const double waypoint_index_blend, const double interpolation_blend) const
{
  // If there are no waypoints we can't do anything
  if (getWayPointCount())
    return false;

  int before = 0, after = 0;
  findWayPointIndicesForDurationAfterStart(request_duration, before, after, waypoint_index_blend);
  waypoints_[before]->interpolate(*waypoints_[after], interpolation_blend, *output_state);
  return true;
}
```

With _waypoint_index_blend_ determining to prefer to fall over the previous or next waypoint closest to the _request_duration_ time.

And _interpolation_blend_ determining the interpolation point in between the _before_ and _after_ indexed waypoints.

In practice I implemented it like this (this may be useful for someone else googling):

``` c++
   /*
    For this example we need all this stuff initialized, this code won't compile, but it's for illustration purposes
   // We need a robot trajectory
    robot_trajectory::RobotTrajectoryPtr robot_traj_;
    // And having a planning_scene_monitor initialized...
    const robot_model_loader::RobotModelLoaderPtr robot_model_loader_;
    robot_model_loader_(new robot_model_loader::RobotModelLoader("robot_description"));
    planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
    planning_scene_monitor_(new planning_scene_monitor::PlanningSceneMonitor(robot_model_loader_);
    const moveit::core::RobotState& current_state = planning_scene_monitor_->getPlanningScene()->getCurrentState();
    // And some trajectory to interpolate
    const trajectory_msgs::JointTrajectory &trajectory;
    robot_traj_->setRobotTrajectoryMsg(current_state, trajectory);
   */

    int before = 0, after = 0;
    // choose a blend (trajectory_time_part) relative of how far in the trajectory we are (in time of total)
    double trajectory_time_part = this_time / final_time;
    robot_traj_->findWayPointIndicesForDurationAfterStart(t_step, before, after, trajectory_time_part);
    double waypoints_part = after / (waypoints -1);
    // choose a blend time (t) [0.0 ... 1.0] in relation of our current waypoint of reference and total time
    double t = waypoints_part * trajectory_time_part;
    robot_traj_->getWayPoint(before).interpolate(robot_traj_->getWayPoint(after), t, *st);
```

Sorry about the offtopic in this PR but I thought it may be useful for someone else.

I don't know if it would be possible to add the version of the function I suggest. I guess it will break ABI.
