### PR TITLE
fixed RevoluteJointModel::computeVariablePositions

### DIFF
--- a/robot_model/src/revolute_joint_model.cpp
+++ b/robot_model/src/revolute_joint_model.cpp
@@ -244,5 +244,7 @@ void moveit::core::RevoluteJointModel::computeVariablePositions(const Eigen::Aff
 {
   Eigen::Quaterniond q(transf.rotation());
   q.normalize();
-  joint_values[0] = acos(q.w())*2.0f;
+  size_t maxIdx;
+  axis_.array().abs().maxCoeff(&maxIdx);
+  joint_values[0] = 2.*atan2(q.vec()[maxIdx] / axis_[maxIdx], q.w());
 }


### PR DESCRIPTION
correctly consider full joint angle range
- 2.*acos(theta/2) only covers half range (as acos only covers 0..pi)
- need to consider sign of quaternion axis w.r.t. rotation axis
