### PR TITLE
[jade] Update Travis conf for Ubuntu Trusty.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,91 +1,41 @@
-# MoveIt Travis Continuous Integration Configuration File
-# Copied from generic one, specialized for running certain tests.
-# Authors: Dave Coleman, Jonathan Bohren, Dave Hershberger
-language:
-  - cpp
-  - python
-python:
-  - "2.7"
+# This config file for Travis CI utilizes ros-industrial/industrial_ci package.
+# For more info for the package, see https://github.com/ros-industrial/industrial_ci/blob/master/README.rst
+sudo: required 
+dist: trusty 
+services:
+  - docker
+language: generic 
 compiler:
   - gcc
-
 notifications:
   email:
+    on_success: always
+    on_failure: always
     recipients:
       - davetcoleman@gmail.com
-    on_success: change #[always|never|change] # default: change
-    on_failure: change #[always|never|change] # default: always
-
-before_install: # Use this to prepare the system to install prerequisites or dependencies
-  # Define some config vars
-  - export ROS_DISTRO=hydro
-  - export CI_SOURCE_PATH=$(pwd)
-  - export REPOSITORY_NAME=${PWD##*/}
-  - echo "Testing branch $TRAVIS_BRANCH of $REPOSITORY_NAME"
-  - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu precise main" > /etc/apt/sources.list.d/ros-latest.list'
-  - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq -y python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-catkin ros-$ROS_DISTRO-ros
-  # MongoDB hack - I don't fully understand this but its for moveit_warehouse
-  - sudo apt-get remove -y mongodb mongodb-10gen
-  - sudo apt-get install -y mongodb-clients mongodb-server -o Dpkg::Options::="--force-confdef" # default actions
-  # Setup rosdep
-  - sudo rosdep init
-  - rosdep update
-
-install: # Use this to install any prerequisites or dependencies necessary to run your build
-  # Create workspace
-  - mkdir -p ~/ros/ws_moveit/src
-  - cd ~/ros/ws_moveit/src
-  - wstool init .
-  # Download non-debian stuff
-  - wstool merge https://raw.github.com/ros-planning/moveit_docs/hydro-devel/moveit.rosinstall
-  - wstool update
-  # Delete the moveit.rosinstall version of this repo and use the one of the branch we are testing
-  - rm -rf $REPOSITORY_NAME
-  - ln -s $CI_SOURCE_PATH . # Link the repo we are testing to the new workspace
-  - cd ../
-  # Install dependencies for source repos
-  - rosdep install --from-paths src --ignore-src --rosdistro $ROS_DISTRO -y
-before_script: # Use this to prepare your build for testing e.g. copy database configurations, environment variables, etc.
-  - source /opt/ros/$ROS_DISTRO/setup.bash  
-
-script: # All commands must exit with code 0 on success. Anything else is considered failure.
-
-  # The main build.  Restricted to 2 parallel jobs to prevent
-  # exhausting memory on Travis servers.
-  - catkin_make -j2
-
-  # Tests need the package's environment 
-  - source devel/setup.bash
-
-  # Go to build dir so can use straight "make"
-  - cd build
-
-  # Build all tests.
-  - make tests
-
-  # Currently not all tests in moveit_core are passing, so I'm
-  # automating the running of the ones that *are* passing to prevent
-  # regressions in those.  When the other tests are fixed, these
-  # run_tests_... lines can all be replaced with a single line like
-  # this:
-  # make run_tests
-  - make run_tests_moveit_core_gtest_test_distance_field
-  - make run_tests_moveit_core_gtest_test_robot_model
-  - make run_tests_moveit_core_gtest_test_robot_state
-  - make run_tests_moveit_core_gtest_test_robot_state_complex
-  - make run_tests_moveit_core_gtest_test_transforms
-  - make run_tests_moveit_core_gtest_test_voxel_grid
-  - make run_tests_moveit_core_gtest_test_world
-  - make run_tests_moveit_core_gtest_test_world_diff
-  
-  # Run downstream tests as well.
-  # - make run_tests_moveit_ros_perception # this requires glut and therefore a video card.
-  - make run_tests_pr2_moveit_tests
-
-  # "make run_tests" and friends return success even when tests fail,
-  # so here we run catkin_test_results which summarizes the results
-  # and returns a result code indicating whether there were any
-  # failures or not.
-  - catkin_test_results .
+      - gm130s@gmail.com
+env:
+  matrix:
+    - ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu  USE_DEB=true
+    - ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu  USE_DEB=true
+    - ROS_DISTRO="jade"   PRERELEASE=true
+    - ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu  USE_DEB=true
+    - ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu  USE_DEB=true
+matrix:
+  allow_failures:
+    - env: ROS_DISTRO="jade"   PRERELEASE=true  # Run docker-based ROS prerelease test http://wiki.ros.org/bloom/Tutorials/PrereleaseTest Because we might not want to run prerelease test for all PRs, it's omitted from pass-fail criteria.
+    - env: ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu  USE_DEB=true
+    - env: ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu  USE_DEB=true
+install:
+  - if [[ ${PRERELEASE} == true ]]; then sudo usermod -aG docker ubuntu; fi
+  # ROS Buildfarm for prerelease http://wiki.ros.org/regression_tests#How_do_I_setup_my_system_to_run_a_prerelease.3F
+  - if [[ ${PRERELEASE} == true ]]; then sudo -E sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'; fi
+  - if [[ ${PRERELEASE} == true ]]; then sudo -E apt-key adv --keyserver hkp://pool.sks-keyservers.net --recv-key 0xB01FA116; fi
+  # Buildfarm workaround for Python3 http://wiki.ros.org/regression_tests#How_do_I_setup_my_system_to_run_a_prerelease.3F
+  - if [[ ${PRERELEASE} == true ]]; then sudo -E apt-get update && sudo -E apt-get install python3 python3-pip python-ros-buildfarm; fi
+  - if [[ ${PRERELEASE} == true ]]; then sudo python3 -m pip install -U EmPy; fi
+script:
+  - if [[ ${PRERELEASE} == true ]]; then mkdir -p /tmp/prerelease_job; cd /tmp/prerelease_job; generate_prerelease_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml jade default ubuntu trusty amd64 moveit_core --level 1 --output-dir ./; fi
+  - if [[ ${PRERELEASE} == true ]]; then ./prerelease.sh; fi
+  - if [[ ${PRERELEASE} != true ]]; then git clone https://github.com/ros-industrial/industrial_ci.git .ci_config && source .ci_config/travis.sh; fi
+#  - source ./travis.sh  # Enable this when you have a package-local script 


### PR DESCRIPTION
Could any admins enable Travis at https://travis-ci.org/profile/ros-planning/ (can be done with a single click) and poke me? Thanks in advance.

(I assume the reason why Travis is disabled is the same as https://github.com/ros-planning/moveit_commander/pull/44#issuecomment-213208068).
