### PR TITLE
Revert "Use libfcl-dev rosdep key in kinetic"

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -41,7 +41,7 @@
   <build_depend>eigen</build_depend>
   <build_depend>boost</build_depend>
   <build_depend>assimp</build_depend>
-  <build_depend>libfcl-dev</build_depend>
+  <build_depend>fcl</build_depend> 
   <build_depend>eigen_stl_containers</build_depend>
   <build_depend>eigen_conversions</build_depend>
   <build_depend version_gte="0.3.4">geometric_shapes</build_depend>
@@ -61,7 +61,7 @@
   <run_depend>eigen</run_depend>
   <run_depend>boost</run_depend>
   <run_depend>assimp</run_depend>
-  <run_depend>libfcl-dev</run_depend>
+  <run_depend>fcl</run_depend>
   <run_depend>eigen_stl_containers</run_depend>  
   <run_depend>eigen_conversions</run_depend>
   <run_depend version_gte="0.3.4">geometric_shapes</run_depend>


### PR DESCRIPTION
Reverts ros-planning/moveit_core#286

it should have targeted `kinetic-devel`
