### PR TITLE
Corrected check in getStateAtDurationFromStart

### DIFF
--- a/robot_trajectory/src/robot_trajectory.cpp
+++ b/robot_trajectory/src/robot_trajectory.cpp
@@ -400,7 +400,7 @@ double robot_trajectory::RobotTrajectory::getWaypointDurationFromStart(std::size
 bool robot_trajectory::RobotTrajectory::getStateAtDurationFromStart(const double request_duration, robot_state::RobotStatePtr& output_state) const
 {
   // If there are no waypoints we can't do anything
-  if (!getWayPointCount())
+  if (getWayPointCount() < 1)
     return false;
 
   int before = 0, after = 0;

--- a/robot_trajectory/src/robot_trajectory.cpp
+++ b/robot_trajectory/src/robot_trajectory.cpp
@@ -400,7 +400,7 @@ double robot_trajectory::RobotTrajectory::getWaypointDurationFromStart(std::size
 bool robot_trajectory::RobotTrajectory::getStateAtDurationFromStart(const double request_duration, robot_state::RobotStatePtr& output_state) const
 {
   // If there are no waypoints we can't do anything
-  if (getWayPointCount())
+  if (!getWayPointCount())
     return false;
 
   int before = 0, after = 0;


### PR DESCRIPTION
The check was returning with 'false' when waypoints were present, instead of the opposite: this prevented the function to correctly execute when a trajectory was set.

Notice that this is already upstream in synaptic v0.7.1 and jade-devel.
