### PR TITLE
Fix fcl implementation so the fcl::CollisionObject's are not created every time a request is made.

### DIFF
--- a/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_common.h
+++ b/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_common.h
@@ -192,6 +192,8 @@ struct FCLGeometry
 
 typedef boost::shared_ptr<FCLGeometry> FCLGeometryPtr;
 typedef boost::shared_ptr<const FCLGeometry> FCLGeometryConstPtr;
+typedef boost::shared_ptr<fcl::CollisionObject> FCLCollisionObjectPtr;
+typedef boost::shared_ptr<const fcl::CollisionObject> FCLCollisionObjectConstPtr;
 
 struct FCLObject
 {
@@ -199,7 +201,7 @@ struct FCLObject
   void unregisterFrom(fcl::BroadPhaseCollisionManager *manager);
   void clear();
 
-  std::vector<boost::shared_ptr<fcl::CollisionObject> > collision_objects_;
+  std::vector<FCLCollisionObjectPtr> collision_objects_;
   std::vector<FCLGeometryConstPtr> collision_geometry_;
 };
 

--- a/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_robot_fcl.h
+++ b/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_robot_fcl.h
@@ -92,6 +92,7 @@ namespace collision_detection
                                const robot_state::RobotState &other_state, const AllowedCollisionMatrix *acm) const;
 
     std::vector<FCLGeometryConstPtr> geoms_;
+    std::vector<FCLCollisionObjectConstPtr> fcl_objs_;
   };
 
 }

--- a/collision_detection_fcl/src/collision_robot_fcl.cpp
+++ b/collision_detection_fcl/src/collision_robot_fcl.cpp
@@ -56,7 +56,7 @@ collision_detection::CollisionRobotFCL::CollisionRobotFCL(const robot_model::Rob
         // Need to store the FCL object so the AABB does not get recreated every time.
         // Every time this object is created, g->computeLocalAABB() is called  which is
         // very expensive and should only be calculated once. To update the AABB, use the
-        // collObj->setTsetTransform and then call collObj->computeAABB() to transform the AABB.
+        // collObj->setTransform and then call collObj->computeAABB() to transform the AABB.
         fcl_objs_[index] = FCLCollisionObjectConstPtr(new fcl::CollisionObject(g->collision_geometry_));
       }
       else
@@ -84,14 +84,14 @@ void collision_detection::CollisionRobotFCL::getAttachedBodyObjects(const robot_
 void collision_detection::CollisionRobotFCL::constructFCLObject(const robot_state::RobotState &state, FCLObject &fcl_obj) const
 {
   fcl_obj.collision_objects_.reserve(geoms_.size());
-  fcl::Transform3f tf;
+  fcl::Transform3f fcl_tf;
 
   for (std::size_t i = 0 ; i < geoms_.size() ; ++i)
     if (geoms_[i] && geoms_[i]->collision_geometry_)
     {
-      transform2fcl(state.getCollisionBodyTransform(geoms_[i]->collision_geometry_data_->ptr.link, geoms_[i]->collision_geometry_data_->shape_index), tf);
+      transform2fcl(state.getCollisionBodyTransform(geoms_[i]->collision_geometry_data_->ptr.link, geoms_[i]->collision_geometry_data_->shape_index), fcl_tf);
       fcl::CollisionObject *collObj = new fcl::CollisionObject(*fcl_objs_[i]);
-      collObj->setTransform(tf);
+      collObj->setTransform(fcl_tf);
       collObj->computeAABB();
       fcl_obj.collision_objects_.push_back(FCLCollisionObjectPtr(collObj));
     }
@@ -107,8 +107,8 @@ void collision_detection::CollisionRobotFCL::constructFCLObject(const robot_stat
     for (std::size_t k = 0 ; k < objs.size() ; ++k)
       if (objs[k]->collision_geometry_)
       {
-        transform2fcl(ab_t[k], tf);
-        fcl_obj.collision_objects_.push_back(FCLCollisionObjectPtr(new fcl::CollisionObject(objs[k]->collision_geometry_, tf)));
+        transform2fcl(ab_t[k], fcl_tf);
+        fcl_obj.collision_objects_.push_back(FCLCollisionObjectPtr(new fcl::CollisionObject(objs[k]->collision_geometry_, fcl_tf)));
         // we copy the shared ptr to the CollisionGeometryData, as this is not stored by the class itself,
         // and would be destroyed when objs goes out of scope.
         fcl_obj.collision_geometry_.push_back(objs[k]);

--- a/collision_detection_fcl/src/collision_robot_fcl.cpp
+++ b/collision_detection_fcl/src/collision_robot_fcl.cpp
@@ -40,14 +40,25 @@ collision_detection::CollisionRobotFCL::CollisionRobotFCL(const robot_model::Rob
   : CollisionRobot(model, padding, scale)
 {
   const std::vector<const robot_model::LinkModel*>& links = robot_model_->getLinkModelsWithCollisionGeometry();
+  std::size_t index;
   geoms_.resize(robot_model_->getLinkGeometryCount());
+  fcl_objs_.resize(robot_model_->getLinkGeometryCount());
   // we keep the same order of objects as what RobotState *::getLinkState() returns
   for (std::size_t i = 0 ; i < links.size() ; ++i)
     for (std::size_t j = 0 ; j < links[i]->getShapes().size() ; ++j)
     {
       FCLGeometryConstPtr g = createCollisionGeometry(links[i]->getShapes()[j], getLinkScale(links[i]->getName()), getLinkPadding(links[i]->getName()), links[i], j);
       if (g)
-        geoms_[links[i]->getFirstCollisionBodyTransformIndex() + j] = g;
+      {
+        index = links[i]->getFirstCollisionBodyTransformIndex() + j;
+        geoms_[index] = g;
+
+        // Need to store the FCL object so the AABB does not get recreated every time.
+        // Every time this object is created, g->computeLocalAABB() is called  which is
+        // very expensive and should only be calculated once. To update the AABB, use the
+        // collObj->setTsetTransform and then call collObj->computeAABB() to transform the AABB.
+        fcl_objs_[index] = FCLCollisionObjectConstPtr(new fcl::CollisionObject(g->collision_geometry_));
+      }
       else
         logError("Unable to construct collision geometry for link '%s'", links[i]->getName().c_str());
     }
@@ -56,6 +67,7 @@ collision_detection::CollisionRobotFCL::CollisionRobotFCL(const robot_model::Rob
 collision_detection::CollisionRobotFCL::CollisionRobotFCL(const CollisionRobotFCL &other) : CollisionRobot(other)
 {
   geoms_ = other.geoms_;
+  fcl_objs_ = other.fcl_objs_;
 }
 
 void collision_detection::CollisionRobotFCL::getAttachedBodyObjects(const robot_state::AttachedBody *ab, std::vector<FCLGeometryConstPtr> &geoms) const
@@ -72,16 +84,19 @@ void collision_detection::CollisionRobotFCL::getAttachedBodyObjects(const robot_
 void collision_detection::CollisionRobotFCL::constructFCLObject(const robot_state::RobotState &state, FCLObject &fcl_obj) const
 {
   fcl_obj.collision_objects_.reserve(geoms_.size());
+  fcl::Transform3f tf;
 
   for (std::size_t i = 0 ; i < geoms_.size() ; ++i)
     if (geoms_[i] && geoms_[i]->collision_geometry_)
     {
-      fcl::CollisionObject *collObj = new fcl::CollisionObject
-        (geoms_[i]->collision_geometry_, transform2fcl(state.getCollisionBodyTransform(geoms_[i]->collision_geometry_data_->ptr.link, geoms_[i]->collision_geometry_data_->shape_index)));
-      fcl_obj.collision_objects_.push_back(boost::shared_ptr<fcl::CollisionObject>(collObj));
-      // the CollisionGeometryData is already stored in the class member geoms_, so we need not copy it
+      transform2fcl(state.getCollisionBodyTransform(geoms_[i]->collision_geometry_data_->ptr.link, geoms_[i]->collision_geometry_data_->shape_index), tf);
+      fcl::CollisionObject *collObj = new fcl::CollisionObject(*fcl_objs_[i]);
+      collObj->setTransform(tf);
+      collObj->computeAABB();
+      fcl_obj.collision_objects_.push_back(FCLCollisionObjectPtr(collObj));
     }
-
+  
+  // TODO: Implement a method for caching fcl::CollisionObject's for robot_state::AttachedBody's
   std::vector<const robot_state::AttachedBody*> ab;
   state.getAttachedBodies(ab);
   for (std::size_t j = 0 ; j < ab.size() ; ++j)
@@ -92,8 +107,8 @@ void collision_detection::CollisionRobotFCL::constructFCLObject(const robot_stat
     for (std::size_t k = 0 ; k < objs.size() ; ++k)
       if (objs[k]->collision_geometry_)
       {
-        fcl::CollisionObject *collObj = new fcl::CollisionObject(objs[k]->collision_geometry_, transform2fcl(ab_t[k]));
-        fcl_obj.collision_objects_.push_back(boost::shared_ptr<fcl::CollisionObject>(collObj));
+        transform2fcl(ab_t[k], tf);
+        fcl_obj.collision_objects_.push_back(FCLCollisionObjectPtr(new fcl::CollisionObject(objs[k]->collision_geometry_, tf)));
         // we copy the shared ptr to the CollisionGeometryData, as this is not stored by the class itself,
         // and would be destroyed when objs goes out of scope.
         fcl_obj.collision_geometry_.push_back(objs[k]);
@@ -191,6 +206,7 @@ void collision_detection::CollisionRobotFCL::checkOtherCollisionHelper(const Col
 
 void collision_detection::CollisionRobotFCL::updatedPaddingOrScaling(const std::vector<std::string> &links)
 {
+  std::size_t index;
   for (std::size_t i = 0 ; i < links.size() ; ++i)
   {
     const robot_model::LinkModel *lmodel = robot_model_->getLinkModel(links[i]);
@@ -200,7 +216,11 @@ void collision_detection::CollisionRobotFCL::updatedPaddingOrScaling(const std::
       {
         FCLGeometryConstPtr g = createCollisionGeometry(lmodel->getShapes()[j], getLinkScale(lmodel->getName()), getLinkPadding(lmodel->getName()), lmodel, j);
         if (g)
-          geoms_[lmodel->getFirstCollisionBodyTransformIndex() + j] = g;
+        {
+          index = lmodel->getFirstCollisionBodyTransformIndex() + j;
+          geoms_[index] = g;
+          fcl_objs_[index] = FCLCollisionObjectConstPtr(new fcl::CollisionObject(g->collision_geometry_));
+        }
       }
     }
     else


### PR DESCRIPTION
Every time a collision or distance request is made all of the fcl::CollisionObjects are recreated shown [here](https://github.com/ros-planning/moveit_core/blob/indigo-devel/collision_detection_fcl/src/collision_robot_fcl.cpp#L76-L83). During the creation of the fcl::CollisionObject it computes the AABB of the passed geometry as shown [here](https://github.com/flexible-collision-library/fcl/blob/bdb34882ab2b5cdc14aee56bd65ab5723a15a589/include/fcl/collision_object.h#L171-L176). This calculation is very expensive because it has to walk the mesh twice as shown [here](https://github.com/flexible-collision-library/fcl/blob/bdb34882ab2b5cdc14aee56bd65ab5723a15a589/src/BVH/BVH_model.cpp#L857-L877). The calculation of the geometries AABB is only required once and then it can easily be update by providing the TF using [CollisionObject::setTransform](https://github.com/flexible-collision-library/fcl/blob/master/include/fcl/collision_object.h#L283-L286) followed by calling the [CollisionObject::updateAABB](https://github.com/flexible-collision-library/fcl/blob/master/include/fcl/collision_object.h#L201-L214) which simply re-sizes the AABB based on the transform as shown [here](https://github.com/Levi-Armstrong/moveit_core/blob/improveCollRobotIndigo_V2/collision_detection_fcl/src/collision_robot_fcl.cpp#L92-L96). It is also seen here that I am creating a copy of the cached fcl::CollisionObject which is to maintain thread safe.

I performed some baseline testing. The testing was performed using a joint interpolated planner and performing 100 planning requests using the same start and goal then taking the average of the time it took to calculate the trajectory where each performed a 100 collision checks. I performed this using both methods where I changes the meshing of a single object in the urdf to where the total triangle count was 10K, 500K and 10,000K. The performance improvements are shown below and they are significant.

| Triangle Count (K) | indigo-devel (sec) | New Method (sec) | % Improvement | Speed Improvement |
| --- | :-: | :-: | :-: | --: |
| 10 | 0.0129 | 0.00229 | 82.25% | 5.6X |
| 500 | 0.1459 | 0.00229 | 98.43% | 63.7X |
| 10,000 | 3.1449 | 0.00263 | 99.92% | 1195.8X |
