### PR TITLE
planning_scene updates: expose success state to caller

### DIFF
--- a/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -677,18 +677,18 @@ public:
   /** \brief Apply changes to this planning scene as diffs, even if the message itself is not marked as being a diff (is_diff
       member). A parent is not required to exist. However, the existing data in the planning instance is not cleared. Data from
       the message is only appended (and in cases such as e.g., the robot state, is overwritten). */
-  void setPlanningSceneDiffMsg(const moveit_msgs::PlanningScene &scene);
+  bool setPlanningSceneDiffMsg(const moveit_msgs::PlanningScene &scene);
 
   /** \brief Set this instance of a planning scene to be the same as the one serialized in the \e scene message, even if the message itself is marked as being a diff (is_diff member) */
-  void setPlanningSceneMsg(const moveit_msgs::PlanningScene &scene);
+  bool setPlanningSceneMsg(const moveit_msgs::PlanningScene &scene);
 
   /** \brief Call setPlanningSceneMsg() or setPlanningSceneDiffMsg() depending on how the is_diff member of the message is set */
-  void usePlanningSceneMsg(const moveit_msgs::PlanningScene &scene);
+  bool usePlanningSceneMsg(const moveit_msgs::PlanningScene &scene);
 
   bool processCollisionObjectMsg(const moveit_msgs::CollisionObject &object);
   bool processAttachedCollisionObjectMsg(const moveit_msgs::AttachedCollisionObject &object);
 
-  void processPlanningSceneWorldMsg(const moveit_msgs::PlanningSceneWorld &world);
+  bool processPlanningSceneWorldMsg(const moveit_msgs::PlanningSceneWorld &world);
 
   void processOctomapMsg(const octomap_msgs::OctomapWithPose &map);
   void processOctomapMsg(const octomap_msgs::Octomap &map);


### PR DESCRIPTION
This is required to get the information back for the
ApplyPlanningSceneService.

This is required for https://github.com/ros-planning/moveit_ros/pull/686

As it turns out, according to abi-compliance-checker these changes
are _also_ ABI compliant... I didn't expect that.
