### PR TITLE
Reduced excessive console output during tests

### DIFF
--- a/distance_field/test/test_distance_field.cpp
+++ b/distance_field/test/test_distance_field.cpp
@@ -466,7 +466,7 @@ TEST(TestSignedPropagationDistanceField, TestSignedAddRemovePoints)
   tf::poseMsgToEigen(p, p_eigen);
 
   gradient_df.addShapeToField(&sphere, p_eigen);
-  printBoth(gradient_df, numX, numY, numZ);
+  //printBoth(gradient_df, numX, numY, numZ);
   EXPECT_GT(gradient_df.getCell(5,5,5).negative_distance_square_, 1);
   //all negative cells should have gradients that point towards cells with distance 1
   for (int z=1; z<df.getZNumCells()-1; z++) {

--- a/robot_model/test/test.cpp
+++ b/robot_model/test/test.cpp
@@ -91,7 +91,7 @@ TEST_F(LoadPlanningModelsPr2, InitOK)
 
 TEST_F(LoadPlanningModelsPr2, Model)
 {
-  robot_model->printModelInfo(std::cout);
+  //robot_model->printModelInfo(std::cout);
 
   const std::vector<const moveit::core::JointModel*> &joints = robot_model->getJointModels();
   for (std::size_t i = 0 ; i < joints.size() ; ++i)


### PR DESCRIPTION
When running moveit_core tests there was a ton of output that slowed down the process - now it is optional through in-code verbose flag.
