### PR TITLE
Add object types when requesting attached bodies in planning scene msg

### DIFF
--- a/planning_scene/src/planning_scene.cpp
+++ b/planning_scene/src/planning_scene.cpp
@@ -471,7 +471,20 @@ void planning_scene::PlanningScene::pushDiffs(const PlanningScenePtr &scene)
     scene->getTransformsNonConst().setAllTransforms(ftf_->getAllTransforms());
 
   if (kstate_)
+  {
     scene->getCurrentStateNonConst() = *kstate_;
+    // push colors and types for attached objects
+    std::vector<const moveit::core::AttachedBody*> attached_objs;
+    kstate_->getAttachedBodies(attached_objs);
+    for(std::vector<const moveit::core::AttachedBody*>::const_iterator it = attached_objs.begin();
+            it != attached_objs.end(); ++it)
+    {
+        if(hasObjectType((*it)->getName()))
+            scene->setObjectType((*it)->getName(), getObjectType((*it)->getName()));
+        if(hasObjectColor((*it)->getName()))
+            scene->setObjectColor((*it)->getName(), getObjectColor((*it)->getName()));
+    }
+  }
 
   if (acm_)
     scene->getAllowedCollisionMatrixNonConst() = *acm_;
@@ -909,16 +922,20 @@ void planning_scene::PlanningScene::getPlanningSceneMsg(moveit_msgs::PlanningSce
   if (comp.components & moveit_msgs::PlanningSceneComponents::TRANSFORMS)
     getTransforms().copyTransforms(scene_msg.fixed_frame_transforms);
 
-  if (comp.components & moveit_msgs::PlanningSceneComponents::ROBOT_STATE_ATTACHED_OBJECTS) {
+  if (comp.components & moveit_msgs::PlanningSceneComponents::ROBOT_STATE_ATTACHED_OBJECTS)
+  {
     robot_state::robotStateToRobotStateMsg(getCurrentState(), scene_msg.robot_state, true);
-    for(std::vector<moveit_msgs::AttachedCollisionObject>::iterator it
-            = scene_msg.robot_state.attached_collision_objects.begin();
-            it != scene_msg.robot_state.attached_collision_objects.end(); ++it) {
-        if(hasObjectType(it->object.id)) {
+    for(std::vector<moveit_msgs::AttachedCollisionObject>::iterator it = scene_msg.robot_state.attached_collision_objects.begin();
+            it != scene_msg.robot_state.attached_collision_objects.end(); ++it)
+    {
+        if(hasObjectType(it->object.id))
+        {
             it->object.type = getObjectType(it->object.id);
         }
     }
-  } else if (comp.components & moveit_msgs::PlanningSceneComponents::ROBOT_STATE) {
+  }
+  else if (comp.components & moveit_msgs::PlanningSceneComponents::ROBOT_STATE)
+  {
       robot_state::robotStateToRobotStateMsg(getCurrentState(), scene_msg.robot_state, false);
   }
 

--- a/planning_scene/src/planning_scene.cpp
+++ b/planning_scene/src/planning_scene.cpp
@@ -909,11 +909,18 @@ void planning_scene::PlanningScene::getPlanningSceneMsg(moveit_msgs::PlanningSce
   if (comp.components & moveit_msgs::PlanningSceneComponents::TRANSFORMS)
     getTransforms().copyTransforms(scene_msg.fixed_frame_transforms);
 
-  if (comp.components & moveit_msgs::PlanningSceneComponents::ROBOT_STATE_ATTACHED_OBJECTS)
+  if (comp.components & moveit_msgs::PlanningSceneComponents::ROBOT_STATE_ATTACHED_OBJECTS) {
     robot_state::robotStateToRobotStateMsg(getCurrentState(), scene_msg.robot_state, true);
-  else
-    if (comp.components & moveit_msgs::PlanningSceneComponents::ROBOT_STATE)
+    for(std::vector<moveit_msgs::AttachedCollisionObject>::iterator it
+            = scene_msg.robot_state.attached_collision_objects.begin();
+            it != scene_msg.robot_state.attached_collision_objects.end(); ++it) {
+        if(hasObjectType(it->object.id)) {
+            it->object.type = getObjectType(it->object.id);
+        }
+    }
+  } else if (comp.components & moveit_msgs::PlanningSceneComponents::ROBOT_STATE) {
       robot_state::robotStateToRobotStateMsg(getCurrentState(), scene_msg.robot_state, false);
+  }
 
   if (comp.components & moveit_msgs::PlanningSceneComponents::ALLOWED_COLLISION_MATRIX)
     getAllowedCollisionMatrix().getMessage(scene_msg.allowed_collision_matrix);


### PR DESCRIPTION
Object types for attached bodies are currently not retrieved, when requesting a planning scene msg.     8db6548 fixes this.

In addition attached objects' types and colors are never pushed in pushDiffs, i.e., whenever pushDiffs was called, this information is lost for all attached bodies. 9ac5ca3 is added for that.
