### PR TITLE
Add a missing #include <boost/bind.hpp>

### DIFF
--- a/collision_detection_fcl/src/collision_world_fcl.cpp
+++ b/collision_detection_fcl/src/collision_world_fcl.cpp
@@ -39,6 +39,7 @@
 #include <fcl/traversal/traversal_node_bvhs.h>
 #include <fcl/traversal/traversal_node_setup.h>
 #include <fcl/collision_node.h>
+#include <boost/bind.hpp>
 
 collision_detection::CollisionWorldFCL::CollisionWorldFCL() :
   CollisionWorld()


### PR DESCRIPTION
This PR adds a missing `#include <boost/bind.hpp>` which caused a compilation failure on Arch Linux.
