### PR TITLE
Use std::shared_ptr for octomap and FCL types.

### DIFF
--- a/collision_detection/src/collision_octomap_filter.cpp
+++ b/collision_detection/src/collision_octomap_filter.cpp
@@ -41,6 +41,8 @@
 #include <octomap/math/Utils.h>
 #include <octomap/octomap.h>
 
+#include <memory>
+
 //static const double ISO_VALUE  = 0.5; // TODO magic number! (though, probably a good one).
 //static const double R_MULTIPLE = 1.5; // TODO magic number! (though, probably a good one).
 
@@ -113,7 +115,7 @@ int collision_detection::refineContactNormals(const World::ObjectConstPtr& objec
       boost::shared_ptr<const shapes::OcTree> shape_octree = boost::dynamic_pointer_cast<const shapes::OcTree>(shape);
       if(shape_octree)
       {
-        boost::shared_ptr<const octomap::OcTree> octree = shape_octree->octree;
+        std::shared_ptr<const octomap::OcTree> octree = shape_octree->octree;
         cell_size = octree->getResolution();
         for(size_t contact_index = 0; contact_index < contact_vector.size(); contact_index++)
         {

--- a/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_common.h
+++ b/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_common.h
@@ -42,6 +42,7 @@
 #include <fcl/broadphase/broadphase.h>
 #include <fcl/collision.h>
 #include <fcl/distance.h>
+#include <memory>
 #include <set>
 
 namespace collision_detection
@@ -186,14 +187,14 @@ struct FCLGeometry
     collision_geometry_->setUserData(collision_geometry_data_.get());
   }
 
-  boost::shared_ptr<fcl::CollisionGeometry> collision_geometry_;
+  std::shared_ptr<fcl::CollisionGeometry> collision_geometry_;
   boost::shared_ptr<CollisionGeometryData>  collision_geometry_data_;
 };
 
-typedef boost::shared_ptr<FCLGeometry> FCLGeometryPtr;
-typedef boost::shared_ptr<const FCLGeometry> FCLGeometryConstPtr;
-typedef boost::shared_ptr<fcl::CollisionObject> FCLCollisionObjectPtr;
-typedef boost::shared_ptr<const fcl::CollisionObject> FCLCollisionObjectConstPtr;
+typedef std::shared_ptr<FCLGeometry> FCLGeometryPtr;
+typedef std::shared_ptr<const FCLGeometry> FCLGeometryConstPtr;
+typedef std::shared_ptr<fcl::CollisionObject> FCLCollisionObjectPtr;
+typedef std::shared_ptr<const fcl::CollisionObject> FCLCollisionObjectConstPtr;
 
 struct FCLObject
 {
@@ -208,7 +209,7 @@ struct FCLObject
 struct FCLManager
 {
   FCLObject                                          object_;
-  boost::shared_ptr<fcl::BroadPhaseCollisionManager> manager_;
+  std::shared_ptr<fcl::BroadPhaseCollisionManager> manager_;
 };
 
 bool collisionCallback(fcl::CollisionObject *o1, fcl::CollisionObject *o2, void *data);

--- a/collision_detection_fcl/src/collision_world_fcl.cpp
+++ b/collision_detection_fcl/src/collision_world_fcl.cpp
@@ -148,7 +148,7 @@ void collision_detection::CollisionWorldFCL::constructFCLObject(const World::Obj
     if (g)
     {
       fcl::CollisionObject *co = new fcl::CollisionObject(g->collision_geometry_,  transform2fcl(obj->shape_poses_[i]));
-      fcl_obj.collision_objects_.push_back(boost::shared_ptr<fcl::CollisionObject>(co));
+      fcl_obj.collision_objects_.push_back(std::shared_ptr<fcl::CollisionObject>(co));
       fcl_obj.collision_geometry_.push_back(g);
     }
   }

--- a/collision_detection_fcl/test/test_fcl_collision_detection.cpp
+++ b/collision_detection_fcl/test/test_fcl_collision_detection.cpp
@@ -86,7 +86,7 @@ protected:
       }
       xml_file.close();
       urdf_model_ = urdf::parseURDF(xml_string);
-      urdf_ok_ = urdf_model_;
+      urdf_ok_ = static_cast<bool>(urdf_model_);
     }
     else
     {

--- a/constraint_samplers/test/test_constraint_samplers.cpp
+++ b/constraint_samplers/test/test_constraint_samplers.cpp
@@ -695,8 +695,8 @@ TEST_F(LoadPlanningModelsPr2, PoseConstraintSamplerManager)
   EXPECT_TRUE(s.get() != NULL);
   constraint_samplers::IKConstraintSampler* iks = dynamic_cast<constraint_samplers::IKConstraintSampler*>(s.get());
   ASSERT_TRUE(iks);
-  ASSERT_TRUE(iks->getPositionConstraint());
-  ASSERT_TRUE(iks->getOrientationConstraint());
+  ASSERT_TRUE(static_cast<bool>(iks->getPositionConstraint()));
+  ASSERT_TRUE(static_cast<bool>(iks->getOrientationConstraint()));
 
   static const int NT = 100;
   int succ = 0;
@@ -720,7 +720,7 @@ TEST_F(LoadPlanningModelsPr2, PoseConstraintSamplerManager)
 
   iks = dynamic_cast<constraint_samplers::IKConstraintSampler*>(s.get());
   ASSERT_TRUE(iks);
-  ASSERT_TRUE(iks->getOrientationConstraint());
+  ASSERT_TRUE(static_cast<bool>(iks->getOrientationConstraint()));
   EXPECT_NEAR(iks->getOrientationConstraint()->getXAxisTolerance(),.1, .0001);
 }
 
@@ -740,9 +740,9 @@ TEST_F(LoadPlanningModelsPr2, JointVersusPoseConstraintSamplerManager)
   con.joint_constraints[0].weight = 1.0;
 
   constraint_samplers::ConstraintSamplerPtr s = constraint_samplers::ConstraintSamplerManager::selectDefaultSampler(ps, "right_arm", con);
-  EXPECT_FALSE(s);
+  EXPECT_FALSE(static_cast<bool>(s));
   s = constraint_samplers::ConstraintSamplerManager::selectDefaultSampler(ps, "left_arm", con);
-  EXPECT_TRUE(s);
+  EXPECT_TRUE(static_cast<bool>(s));
 
   con.joint_constraints.resize(7);
 
@@ -784,7 +784,7 @@ TEST_F(LoadPlanningModelsPr2, JointVersusPoseConstraintSamplerManager)
   con.joint_constraints[6].weight = 1.0;
 
   s = constraint_samplers::ConstraintSamplerManager::selectDefaultSampler(ps, "left_arm", con);
-  EXPECT_TRUE(s);
+  EXPECT_TRUE(static_cast<bool>(s));
 
   con.position_constraints.resize(1);
 
@@ -812,13 +812,13 @@ TEST_F(LoadPlanningModelsPr2, JointVersusPoseConstraintSamplerManager)
 
   //this still works, but we should get a JointConstraintSampler
   s = constraint_samplers::ConstraintSamplerManager::selectDefaultSampler(ps, "left_arm", con);
-  EXPECT_TRUE(s);
+  EXPECT_TRUE(static_cast<bool>(s));
   constraint_samplers::JointConstraintSampler* jcs = dynamic_cast<constraint_samplers::JointConstraintSampler*>(s.get());
   EXPECT_TRUE(jcs);
 
   con.position_constraints[0].link_name = "l_wrist_roll_link";
   s = constraint_samplers::ConstraintSamplerManager::selectDefaultSampler(ps, "left_arm", con);
-  EXPECT_TRUE(s);
+  EXPECT_TRUE(static_cast<bool>(s));
   jcs = dynamic_cast<constraint_samplers::JointConstraintSampler*>(s.get());
   EXPECT_FALSE(jcs);
   constraint_samplers::IKConstraintSampler* iks = dynamic_cast<constraint_samplers::IKConstraintSampler*>(s.get());
@@ -844,7 +844,7 @@ TEST_F(LoadPlanningModelsPr2, JointVersusPoseConstraintSamplerManager)
 
   //we still get an IK sampler with just the position constraint
   s = constraint_samplers::ConstraintSamplerManager::selectDefaultSampler(ps, "left_arm", con);
-  EXPECT_TRUE(s);
+  EXPECT_TRUE(static_cast<bool>(s));
   ucs = dynamic_cast<constraint_samplers::UnionConstraintSampler*>(s.get());
   ASSERT_TRUE(ucs);
   jcs = dynamic_cast<constraint_samplers::JointConstraintSampler*>(ucs->getSamplers()[0].get());
@@ -852,29 +852,29 @@ TEST_F(LoadPlanningModelsPr2, JointVersusPoseConstraintSamplerManager)
 
   ASSERT_TRUE(iks);
   ASSERT_TRUE(jcs);
-  EXPECT_TRUE(iks->getPositionConstraint());
+  EXPECT_TRUE(static_cast<bool>(iks->getPositionConstraint()));
   EXPECT_FALSE(iks->getOrientationConstraint());
 
   con.orientation_constraints[0].link_name = "l_wrist_roll_link";
 
   //now they both are good
   s = constraint_samplers::ConstraintSamplerManager::selectDefaultSampler(ps, "left_arm", con);
-  EXPECT_TRUE(s);
+  EXPECT_TRUE(static_cast<bool>(s));
   ucs = dynamic_cast<constraint_samplers::UnionConstraintSampler*>(s.get());
   iks = dynamic_cast<constraint_samplers::IKConstraintSampler*>(ucs->getSamplers()[1].get());
   ASSERT_TRUE(iks);
-  EXPECT_TRUE(iks->getPositionConstraint());
-  EXPECT_TRUE(iks->getOrientationConstraint());
+  EXPECT_TRUE(static_cast<bool>(iks->getPositionConstraint()));
+  EXPECT_TRUE(static_cast<bool>(iks->getOrientationConstraint()));
 
   //now just the orientation constraint is good
   con.position_constraints[0].link_name = "r_wrist_roll_link";
   s = constraint_samplers::ConstraintSamplerManager::selectDefaultSampler(ps, "left_arm", con);
-  ASSERT_TRUE(s);
+  ASSERT_TRUE(static_cast<bool>(s));
   ucs = dynamic_cast<constraint_samplers::UnionConstraintSampler*>(s.get());
   iks = dynamic_cast<constraint_samplers::IKConstraintSampler*>(ucs->getSamplers()[1].get());
   ASSERT_TRUE(iks);
   EXPECT_FALSE(iks->getPositionConstraint());
-  EXPECT_TRUE(iks->getOrientationConstraint());
+  EXPECT_TRUE(static_cast<bool>(iks->getOrientationConstraint()));
 
   //now if we constraint all the joints, we get a joint constraint sampler
   con.joint_constraints.resize(8);
@@ -885,7 +885,7 @@ TEST_F(LoadPlanningModelsPr2, JointVersusPoseConstraintSamplerManager)
   con.joint_constraints[7].weight = 1.0;
 
   s = constraint_samplers::ConstraintSamplerManager::selectDefaultSampler(ps, "left_arm", con);
-  EXPECT_TRUE(s);
+  EXPECT_TRUE(static_cast<bool>(s));
   jcs = dynamic_cast<constraint_samplers::JointConstraintSampler*>(s.get());
   ASSERT_TRUE(jcs);
 }
@@ -1106,7 +1106,7 @@ TEST_F(LoadPlanningModelsPr2, SubgroupPoseConstraintsSampler)
 
   robot_state::Transforms &tf = ps->getTransformsNonConst();
   constraint_samplers::ConstraintSamplerPtr s = constraint_samplers::ConstraintSamplerManager::selectDefaultSampler(ps, "arms", c);
-  EXPECT_TRUE(s);
+  EXPECT_TRUE(static_cast<bool>(s));
   constraint_samplers::UnionConstraintSampler* ucs = dynamic_cast<constraint_samplers::UnionConstraintSampler*>(s.get());
   EXPECT_TRUE(ucs);
 

--- a/distance_field/test/test_distance_field.cpp
+++ b/distance_field/test/test_distance_field.cpp
@@ -43,7 +43,8 @@
 #include <geometric_shapes/body_operations.h>
 #include <eigen_conversions/eigen_msg.h>
 #include <octomap/octomap.h>
-#include <boost/make_shared.hpp>
+
+#include <memory>
 
 
 using namespace distance_field;
@@ -811,7 +812,7 @@ TEST(TestSignedPropagationDistanceField, TestOcTree)
   std::cout << "Occupied cells " << countOccupiedCells(df_highres) << std::endl;
 
   //testing adding shape that happens to be octree
-  boost::shared_ptr<octomap::OcTree> tree_shape(new octomap::OcTree(.05));
+  std::shared_ptr<octomap::OcTree> tree_shape(new octomap::OcTree(.05));
   octomap::point3d tpoint1(1.0,.5,1.0);
   octomap::point3d tpoint2(1.7,.5,.5);
   octomap::point3d tpoint3(1.8,.5,.5);
@@ -819,7 +820,7 @@ TEST(TestSignedPropagationDistanceField, TestOcTree)
   tree_shape->updateNode(tpoint2, true);
   tree_shape->updateNode(tpoint3, true);
 
-  boost::shared_ptr<shapes::OcTree> shape_oc(new shapes::OcTree(tree_shape));
+  std::shared_ptr<shapes::OcTree> shape_oc(new shapes::OcTree(tree_shape));
 
   PropagationDistanceField df_test_shape_1(PERF_WIDTH, PERF_HEIGHT, PERF_DEPTH, PERF_RESOLUTION,
                                            PERF_ORIGIN_X, PERF_ORIGIN_Y, PERF_ORIGIN_Z, PERF_MAX_DIST, false);

--- a/package.xml
+++ b/package.xml
@@ -29,7 +29,6 @@
   <build_depend>geometry_msgs</build_depend>
   <build_depend>kdl_parser</build_depend>
   <build_depend>libconsole-bridge-dev</build_depend>
-  <build_depend>libfcl-dev</build_depend>
   <build_depend>liburdfdom-dev</build_depend>
   <build_depend>liburdfdom-headers-dev</build_depend>
   <build_depend>moveit_msgs</build_depend>
@@ -55,7 +54,6 @@
   <run_depend>geometry_msgs</run_depend>
   <run_depend>kdl_parser</run_depend>
   <run_depend>libconsole-bridge-dev</run_depend>
-  <run_depend>libfcl-dev</run_depend>
   <run_depend>liburdfdom-dev</run_depend>
   <run_depend>liburdfdom-headers-dev</run_depend>
   <run_depend>moveit_msgs</run_depend>

--- a/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -55,6 +55,7 @@
 #include <boost/shared_ptr.hpp>
 #include <boost/function.hpp>
 #include <boost/concept_check.hpp>
+#include <memory>
 
 /** \brief This namespace includes the central class for representing planning contexts */
 namespace planning_scene
@@ -692,7 +693,7 @@ public:
 
   void processOctomapMsg(const octomap_msgs::OctomapWithPose &map);
   void processOctomapMsg(const octomap_msgs::Octomap &map);
-  void processOctomapPtr(const boost::shared_ptr<const octomap::OcTree> &octree, const Eigen::Affine3d &t);
+  void processOctomapPtr(const std::shared_ptr<const octomap::OcTree> &octree, const Eigen::Affine3d &t);
 
   /**
    * \brief Clear all collision objects in planning scene

--- a/planning_scene/src/planning_scene.cpp
+++ b/planning_scene/src/planning_scene.cpp
@@ -44,6 +44,7 @@
 #include <moveit/exceptions/exceptions.h>
 #include <octomap_msgs/conversions.h>
 #include <eigen_conversions/eigen_msg.h>
+#include <memory>
 #include <set>
 
 namespace planning_scene
@@ -1283,7 +1284,7 @@ void planning_scene::PlanningScene::processOctomapMsg(const octomap_msgs::Octoma
     return;
   }
 
-  boost::shared_ptr<octomap::OcTree> om(static_cast<octomap::OcTree*>(octomap_msgs::msgToMap(map)));
+  std::shared_ptr<octomap::OcTree> om(static_cast<octomap::OcTree*>(octomap_msgs::msgToMap(map)));
   if (!map.header.frame_id.empty())
   {
     const Eigen::Affine3d &t = getTransforms().getTransform(map.header.frame_id);
@@ -1317,7 +1318,7 @@ void planning_scene::PlanningScene::processOctomapMsg(const octomap_msgs::Octoma
     return;
   }
 
-  boost::shared_ptr<octomap::OcTree> om(static_cast<octomap::OcTree*>(octomap_msgs::msgToMap(map.octomap)));
+  std::shared_ptr<octomap::OcTree> om(static_cast<octomap::OcTree*>(octomap_msgs::msgToMap(map.octomap)));
   const Eigen::Affine3d &t = getTransforms().getTransform(map.header.frame_id);
   Eigen::Affine3d p;
   tf::poseMsgToEigen(map.origin, p);
@@ -1325,7 +1326,7 @@ void planning_scene::PlanningScene::processOctomapMsg(const octomap_msgs::Octoma
   world_->addToObject(OCTOMAP_NS, shapes::ShapeConstPtr(new shapes::OcTree(om)), p);
 }
 
-void planning_scene::PlanningScene::processOctomapPtr(const boost::shared_ptr<const octomap::OcTree> &octree, const Eigen::Affine3d &t)
+void planning_scene::PlanningScene::processOctomapPtr(const std::shared_ptr<const octomap::OcTree> &octree, const Eigen::Affine3d &t)
 {
   collision_detection::CollisionWorld::ObjectConstPtr map = world_->getObject(OCTOMAP_NS);
   if (map)


### PR DESCRIPTION
As also discussion in #315, this PR changes `boost::shared_ptr` to `std::shared_ptr` where required for compatibility with FCL 0.5.

To be entirely honest, I'm not sure if this affects the public interface of `moveit_core`. Is `collision_detection_fcl` exposed to external code?

This PR needs ros-planning/geometric_shapes#47 before it will compile.
